### PR TITLE
Adding classical limit in anharmonic free energy

### DIFF
--- a/src/anharmonic_free_energy/main.f90
+++ b/src/anharmonic_free_energy/main.f90
@@ -195,11 +195,15 @@ getenergy: block
     toev = lo_Hartree_to_eV / uc%na
 
     ! Some heuristics to figure out what the temperature is.
-    f_ph=dr%phonon_free_energy(sim%temperature_thermostat)
+    if (opts%classical) then
+        f_ph=dr%phonon_free_energy_classical(sim%temperature_thermostat)
+    else
+        f_ph=dr%phonon_free_energy(sim%temperature_thermostat)
+    end if
 
     if ( havehighorder ) then
         select type(qp); type is(lo_fft_mesh)
-            call perturbative_anharmonic_free_energy(uc,fct,fcf,qp,dr,sim%temperature_thermostat,ah3,ah4,mw,mem,opts%verbosity+1)
+            call perturbative_anharmonic_free_energy(uc,fct,fcf,qp,dr,sim%temperature_thermostat,ah3,ah4,opts%classical,mw,mem,opts%verbosity+1)
         end select
     else
         ah3=0.0_r8

--- a/src/anharmonic_free_energy/options.f90
+++ b/src/anharmonic_free_energy/options.f90
@@ -15,6 +15,7 @@ type lo_opts
     integer :: verbosity
     logical :: readqmesh
     integer :: meshtype
+    logical :: classical = .false.
     contains
         procedure :: parse
 end type
@@ -47,6 +48,10 @@ subroutine parse(opts)
         help='Type of integration. 1 is Gaussian, 2 adaptive Gaussian and 3 Tetrahedron.',&
         required=.false.,act='store',def='2',choices='1,2,3',error=lo_status)
         if ( lo_status .ne. 0 ) stop
+    call cli%add(switch='--classical', switch_ab='-cl', &
+        help='Use classical high temperature limit for the high order free energy', &
+        required=.false., act='store_true',def='.false',error=lo_status)
+        if ( lo_status .ne. 0 ) stop
     cli_readiso
     cli_manpage
     cli_verbose
@@ -74,6 +79,7 @@ subroutine parse(opts)
     call cli%get(switch='--meshtype',           val=opts%meshtype,         error=lo_status); errctr=errctr+lo_status
     call cli%get(switch='--integrationtype',    val=opts%integrationtype,  error=lo_status); errctr=errctr+lo_status
     call cli%get(switch='--readiso',            val=opts%readiso,          error=lo_status); errctr=errctr+lo_status
+    call cli%get(switch='--classical',          val=opts%classical,        error=lo_status); errctr=errctr+lo_status
 
     if ( errctr .ne. 0 ) call lo_stop_gracefully(['Failed parsing the command line options'],lo_exitcode_baddim)
 


### PR DESCRIPTION
Adding a --classical option in anharmonic_free energy to ease the comparison with thermodynamic integration.
I don't use the full high temperature simplification (setting $n(\omega) + 1 \approx \frac{k_BT}{\hbar\omega}$ because of the $n(\omega)>>1$ but instead I simply redefine $n(\omega)\approx \frac{k_BT}{\hbar\omega}$ and use the same formula for the anharmonic contributions. It's simpler in the code and should give the same results when the high-temperature limit is actually applicable.)

I also corrected the formula for the third order contribution to the free energy which had a wrong occupation number (a $n(\omega_1)$ instead of $n(\omega_2)$.