### PR TITLE
Correcting forces statistics for high-order force constants in extract_forceconstants

### DIFF
--- a/src/extract_forceconstants/main.f90
+++ b/src/extract_forceconstants/main.f90
@@ -599,8 +599,8 @@ getU0: block
         write (*, '(1X,A15,3(1X,F12.6),5X,A,12X,A)') 'input:', mf0, mf0, sf0, '-', '-'
         if (map%polar .gt. 0) write (*, '(1X,A15,5(1X,F12.6))') 'polar:', mfp, dfp, sfp, 1 - (sfp/sf0)**2, sfp/sf0
         if (map%have_fc_pair) write (*, '(1X,A15,5(1X,F12.6),13X,A)') 'second order:', mf2, df2, sf2, 1 - (sf2/sf0)**2, sf2/sf0, '<-- anharmonicity measure'
-        if (map%have_fc_triplet) write (*, '(1X,A15,4(1X,F12.6))') 'third order:', mf3, df3, sf3, sf3/sf0
-        if (map%have_fc_quartet) write (*, '(1X,A15,4(1X,F12.6))') 'fourth order:', mf4, df4, sf4, sf4/sf0
+        if (map%have_fc_triplet) write (*, '(1X,A15,5(1X,F12.6))') 'third order:', mf3, df3, sf3, 1 - (sf3/sf0)**2, sf3/sf0
+        if (map%have_fc_quartet) write (*, '(1X,A15,5(1X,F12.6))') 'fourth order:', mf4, df4, sf4, 1 - (sf4/sf0)**2, sf4/sf0
 
         write (*, *) ''
         write (*, *) 'BASELINE ENERGY (eV/atom):'


### PR DESCRIPTION
The R^2 for the third and fourth order force constants in the stdout are instead the normalized std of the residuals.
This is just to fix this small issue.