### PR TITLE
Add a lower limit to the mixing parameter in thermal conductivity

### DIFF
--- a/src/thermal_conductivity/pbe.f90
+++ b/src/thermal_conductivity/pbe.f90
@@ -477,7 +477,7 @@ subroutine get_selfconsistent_solution(sc, dr, qp, uc, temperature, niter, tol, 
                 iter, m0(1, 1), m0(2, 2), m0(3, 3), m0(1, 2), m0(1, 3), m0(2, 3), scfcheck(iter)
 
             ! If we had too many iterations I want to adjust the mixing a little
-            if (iter .gt. 15) then
+            if (iter .gt. 15 .and. mixingparameter .gt. 0.10) then
                 mixingparameter = mixingparameter*0.98_r8
             end if
         end block addandcheck


### PR DESCRIPTION
When running thermal conductivity for systems where collective effects are important, you can have a lot of iterations within the IBTE. With the way the mixing parameter is updated, the $F_\lambda$  don't change anymore around the 200 step, the thermal conductivity get stuck and you can never reach convergence for some system (we observed this in 2D planar systems : graphene, h-BN, ...)

With this pull request, I just changed the way the mixing parameter is updated by putting a lower threshold of 0.10 at which it won't evolve anymore.
This correspond to fixing the `mixingparameter` to its value at approximately the 60th iteration, which means that this should have no effect on systems where the IBTE converge normally.

Old way : 
```
if (iter .gt. 15) then
                mixingparameter = mixingparameter*0.98_r8
endif
```

New way
```
if (iter .gt. 15 .and. mixingparameter .gt. 0.10) then
                mixingparameter = mixingparameter*0.98_r8
endif
```