### PR TITLE
ENH: Add phasespace surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,11 @@ tests/test*/disprel_xtck
 # things in the staging area
 staging/
 
+# Coding
+.vscode
+*venv*
+tmp
+
 # Compiled Object files
 *.slo
 *.lo

--- a/build_things.sh
+++ b/build_things.sh
@@ -186,6 +186,7 @@ pack_simulation
 refine_structure
 thermal_conductivity
 anharmonic_free_energy
+phasespace_surface
 "
 
 #some things that are not quite ok yet

--- a/docs/program/README.md
+++ b/docs/program/README.md
@@ -25,3 +25,5 @@
 [`crystal_structure_info`: Report which crystal structure and spacegroup TDEP sees.](crystal_structure_info.md)
 
 [`refine_structure`: Clean up input structures with imprecise symmetry.](refine_structure.md)
+
+[`phasespace_surface`: Compute the phonon scattering phase space.](phasespace_surface.md)

--- a/docs/program/phasespace_surface.md
+++ b/docs/program/phasespace_surface.md
@@ -1,0 +1,62 @@
+
+### Short description
+
+Calculate the three-phonon scattering surface.
+
+### Command line options:
+
+
+
+
+Optional switches:
+
+* `--qpoint value#1 value#2 value#3`  
+    default value 0 0 0  
+    Specify the q-point for which to calculate the scattering surface.
+
+* `--highsymmetrypoint value`  
+    default value none  
+    Same as above, but you can specify the label of a high-symmetry point instead, e.g. "X" or "L".
+
+* `--modespec value#1 [value#2...]`  
+    default value 1 2 3 0 1 100  
+    Specify which surfaces to look at. 6 integers per surface: band1 band2 band3 plus/minus color opacity. Modes go from 1 to number of bands. plus/minus is 0 for plus events 1 for minus. Color from 1-3, opacity from 0-100.
+
+* `--povray`  
+    default value .false.  
+    Write POV-Ray script for rendering.
+
+* `--intensities`  
+    default value .false.  
+    Calculate intensities (matrix elements) as well.
+
+* `--pv_theta_phi value#1 value#2`  
+    default value 20 30  
+    Povray specification, theta and phi angles (in degrees) deteriming camera location.
+
+* `--pv_quality value`  
+    default value 9  
+    Povray rendering quality, 1-9 where 1 is worst.
+
+* `--nband value`  
+    default value -1  
+    Specify first band index
+
+* `--qpoint_grid value#1 value#2 value#3`, `-qg value#1 value#2 value#3`  
+    default value 26 26 26  
+    Density of q-point mesh for Brillouin zone integrations.
+
+* `--readqmesh`  
+    default value .false.  
+    Read the q-point mesh from file. To generate a q-mesh file, see the genkpoints utility.
+
+* `--help`, `-h`  
+    Print this help message
+
+* `--version`, `-v`  
+    Print version
+### Examples
+
+`phasespace_surface --highsymmetrypoint X` 
+
+`phasespace_surface --qpoint 0.1 0.2 0.3` 

--- a/important_settings.cgal
+++ b/important_settings.cgal
@@ -1,0 +1,75 @@
+#!/bin/bash
+# A central place to put all the important paths. You probably have to modify this to make things work.
+
+# the fortran compiler
+FORTRAN_COMPILER="gfortran-13"
+# required compiler flags
+FCFLAGS="-ffree-line-length-none -std=f2008 -cpp -fallow-argument-mismatch"
+# extra flags, for debugging and such
+FCFLAGS_EXTRA=""
+# FCFLAGS_EXTRA="-g -fbacktrace -fcheck=all -finit-real=nan -finit-derived -fmax-errors=10 --pedantic --warn-all"
+# FCFLAGS_EXTRA="-g -fbacktrace -fcheck=all -finit-real=nan -finit-derived -fmax-errors=10 --pedantic -Wall -Wextra -pedantic -Wcast-align -Wdisabled-optimization -Wmissing-include-dirs -Wshadow -Wunused -fdiagnostics-show-option -fcheck=all -Wstrict-overflow=0 -Wrealloc-lhs"
+
+# optimization stuff. Go all in, sometimes
+# OPTIMIZATION_LEVEL="-Ofast"
+OPTIMIZATION_LEVEL="-O3"
+# OPTIMIZATION_LEVEL="-O0"
+OPTIMIZATION_SENSITIVE="-O0"
+
+# the flag that sets the default real to a double.
+DOUBLE_FLAG="-fdefault-real-8"
+# The flag that tells the compiler where to put .o and .mod files.
+MODULE_FLAG="-J"
+
+# the header to put in python scripts.
+PYTHONHEADER="#!/usr/bin/env python"
+
+# Which gnuplot terminal to use by default.
+GNUPLOTTERMINAL="aqua"  # nice on OSX, needs aquaterm installed and gnuplot compiled with support for it.
+
+# Precompiler flags. Selecting default gnuplot terminal, and make the progressbars work.
+PRECOMPILER_FLAGS="-DGP${GNUPLOTTERMINAL} -Dclusterprogressbar"
+# PRECOMPILER_FLAGS="-DGP${GNUPLOTTERMINAL} -Dclusterprogressbar -DAGRESSIVE_SANITY"
+#PRECOMPILER_FLAGS="-DGP${GNUPLOTTERMINAL} -Dgfortranprogressbar"
+#PRECOMPILER_FLAGS="-DGP${GNUPLOTTERMINAL} -Dgfortranprogressbar -DAGRESSIVE_SANITY"
+
+# These are the BLAS/LAPACK libraries. On OSX with gfortran, use the built-in 'framework accelerate'
+PATH_TO_BLASLAPACK_LIB=""
+PATH_TO_BLASLAPACK_INC=""
+BLASLAPACK_LIBS="-framework accelerate"
+
+# I use fftw for Fourier transforms.
+PATH_TO_FFTW_LIB="-L/opt/homebrew/lib"
+PATH_TO_FFTW_INC="-I/opt/homebrew/include"
+FFTW_LIBS=""
+FFTW_LIBS="-lfftw3"
+
+# Also need MPI
+PATH_TO_MPI_LIB="-L/opt/homebrew/lib"
+PATH_TO_MPI_INC="-I/opt/homebrew/include"
+MPI_LIBS="-lmpi_mpifh -lmpi"
+
+# I also use HDF5 every now and then
+PATH_TO_HDF5_LIB="-L/Users/flokno/local/hdf5-1.12.2/build_2022_11/lib"
+PATH_TO_HDF5_INC="-I/Users/flokno/local/hdf5-1.12.2/build_2022_11/include"
+HDF5_LIBS="-lhdf5 -lhdf5_fortran"
+
+# Optionally CGAL and FHI-Aims. You probably do not want that.
+USEAIMS="no"
+
+# Let's do it
+USECGAL="yes"
+
+CGAL_PATH=/Users/flokno/local/cgal-5.6.1/build
+
+# CGAL is written in c++. I have wrapper functions in C, that I call from Fortran.
+CPP_COMPILER="gcc-13"
+CPP_FLAGS="--std=c++14 -frounding-math -O3 -Dusecgal -DCGAL_USE_GMP -DCGAL_USE_MPFR -DCGAL_EIGEN3_ENABLED -DNDEBUG -DBOOST_PARAMETER_MAX_ARITY=12 -Wno-deprecated-declarations"
+CGALLINKLINE="-lstdc++ -lmpfr -lgmp -lboost_system -lboost_thread-mt"
+# CGALLINKLINE="-lCGAL -lCGAL_Core" #  -lmpfr -lgmp -lboost_system -lboost_thread-mt"
+# CGALLINKLINE="-lstdc++ -lCGAL -lCGAL_Core -lmpfr -lgmp -lboost_system -lboost_thread-mt"
+# CGALLINKLINE="-lstdc++ -lCGAL -lCGAL_Core -lmpfr -lgmp -lboost_system -lboost_thread-mt"
+
+PATH_TO_CGAL_LIB="-L$CGAL_PATH/lib"
+PATH_TO_CGAL_INC="-I$CGAL_PATH/include/ -I/opt/homebrew/include/eigen3 -I/opt/homebrew/include"
+

--- a/important_settings.tetralith.cgal
+++ b/important_settings.tetralith.cgal
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# A central place to put all the important paths. You probably have to modify this to make
+# things work.
+
+# Sigma/Tetralith 2024:
+module load buildenv-intel/2023a-eb
+module load HDF5/1.12.2-hpc1
+
+# the header to put in python scripts.
+PYTHONHEADER="#!/bin/env python"
+
+# Which gnuplot terminal to use by default.
+GNUPLOTTERMINAL="wxt" # other options are "aqua" and "x11"
+
+# the fortran compiler
+FORTRAN_COMPILER="mpiifort"
+OPTIMIZATION_LEVEL="-O3 -xCORE-AVX512" # first time you try you might want to put this to -O0 to make things compile a little faster.
+#OPTIMIZATION_LEVEL="-O0 -check bounds -check uninit -check pointers -check stack -traceback -g -fpe0 -init=snan,arrays -warn all -warn stderrors -stand f08 -diag-disable 5268"
+
+# Extra options for the compiler to make it play nice
+FCFLAGS="-ip -fpp -fp-model precise -qmkl=cluster"
+
+# flag that specifies location of modules
+MODULE_FLAG="-module"
+
+# Precompiler flags. Selecting default gnuplot terminal, and makes the progressbars work.
+PRECOMPILER_FLAGS="-DGP${GNUPLOTTERMINAL} -Dclusterprogressbar"
+
+# you need BLAS and LAPACK
+PATH_TO_BLASLAPACK_LIB="" # "-L${MKLROOT}/lib/intel64"
+PATH_TO_BLASLAPACK_INC="" # "-I${MKLROOT}/include"
+BLASLAPACK_LIBS="" # "-lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64 -lmkl_scalapack_lp64"
+
+# I need the fftw library
+PATH_TO_FFTW_LIB=""
+PATH_TO_FFTW_INC="" # -I${MKL_ROOT}/include/fftw"
+FFTW_LIBS=""
+
+# Also need MPI
+PATH_TO_MPI_LIB="" # "-L${I_MPI_ROOT}/intel64/lib"
+PATH_TO_MPI_INC="" # "-I${I_MPI_ROOT}/intel64/include"
+MPI_LIBS="" # "-lmpi -lmpifort"
+
+# And a c-compiler
+C_COMPILER="icc"
+
+# And HDF5
+PATH_TO_HDF5_LIB="-L${HDF5_DIR}/lib"
+PATH_TO_HDF5_INC="-I${HDF5_DIR}/include"
+HDF5_LIBS="-lhdf5 -lhdf5_fortran"
+
+# Optionally CGAL and FHI-Aims. You probably do not want that.
+USEAIMS="no"
+
+# Let's do it
+USECGAL="yes"
+
+# need some more modules
+module load GCCcore/11.3.0
+module load POV-Ray/3.7.0.10-hpc1-gcc-2022a-eb
+module load Boost/1.79.0
+module load GMP/6.2.1
+module load MPFR/4.1.0
+module load Eigen/3.4.0
+
+CGAL_PATH="/proj/theophys/users/x_flokn/local/CGAL/cgal-5.6.1/build"
+
+# CGAL is written in c++. I have wrapper functions in C, that I call from Fortran.
+CPP_COMPILER="gcc"
+CPP_FLAGS="--std=c++14 -frounding-math -O3 -Dusecgal -DCGAL_USE_GMP -DCGAL_USE_MPFR -DCGAL_EIGEN3_ENABLED -DNDEBUG -DBOOST_PARAMETER_MAX_ARITY=12 -Wno-deprecated-declarations"
+CGALLINKLINE="-lstdc++ -lmpfr -lgmp -lboost_system"
+
+PATH_TO_CGAL_LIB="-L$CGAL_PATH/lib64"
+PATH_TO_CGAL_INC="-I$CGAL_PATH/include/"
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - Dump dynamical matrices: program/dump_dynamical_matrices.md
     - Crystal structure info: program/crystal_structure_info.md
     - Refine structure: program/refine_structure.md
+    - Phase space: program/phasespace_surface.md
   - Files: files.md
 
 markdown_extensions:

--- a/src/dump_dynamical_matrices/Makefile
+++ b/src/dump_dynamical_matrices/Makefile
@@ -9,8 +9,9 @@ LPATH = -L../../lib $(blaslapackLPATH) $(incLPATHhdf) $(incLPATHmpi) $(incLPATHf
 IPATH = -I../../inc/libolle -I../../inc/libflap $(blaslapackIPATH) $(incIPATHhdf) $(incIPATHmpi) $(incIPATHfft)
 LIBS = -lolle -lflap $(blaslapackLIBS) $(incLIBShdf) $(incLIBSmpi) $(incLIBSfft)
 
-#OPT = -O0 -fbacktrace -fcheck=all -Wall
-F90 = $(FC) $(LPATH) $(IPATH) $(MODULE_FLAG) $(OBJECT_PATH)
+# ok, I think I get this.
+#OPT = -O0 -fbacktrace -fcheck=all -finit-real=nan -finit-derived -fmax-errors=10
+F90 = $(FC) $(LPATH) $(IPATH) $(MODULE_FLAG) $(OBJECT_PATH) #$(warnings_gcc)
 F90FLAGS = $(OPT) $(MODS) $(LIBS)
 
 all: $(PROG)

--- a/src/libolle/cgal_chull3_intersection.cc
+++ b/src/libolle/cgal_chull3_intersection.cc
@@ -7,7 +7,7 @@
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Simple_homogeneous.h>
 #include <CGAL/Homogeneous.h>
-#include <CGAL/gmpq.h>
+#include <CGAL/Gmpq.h>
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/convex_hull_3.h>

--- a/src/phasespace_surface/Makefile
+++ b/src/phasespace_surface/Makefile
@@ -1,0 +1,32 @@
+include Makefile.inc
+CODE = phasespace_surface
+PROG = ../../build/$(CODE)/$(CODE)
+OBJECT_PATH=../../build/$(CODE)/
+
+OBJS = $(OBJECT_PATH)main.o $(OBJECT_PATH)options.o $(OBJECT_PATH)type_phasespacesurface.o
+
+LPATH = -L../../lib $(blaslapackLPATH) $(incLPATHhdf) $(incLPATHmpi)
+IPATH = -I../../inc/libolle -I../../inc/libflap $(blaslapackIPATH) $(incIPATHhdf) $(incIPATHmpi)
+LIBS = -lolle -lflap $(blaslapackLIBS) $(incLIBShdf) $(incLIBSmpi)
+
+#OPT = -O0 -fbacktrace -fcheck=all -finit-real=nan -finit-derived -fmax-errors=10
+F90 = $(FC) $(LPATH) $(IPATH) $(MODULE_FLAG) $(OBJECT_PATH)
+F90FLAGS = $(OPT) $(MODS) $(LIBS)
+
+all: $(PROG)
+
+$(PROG): $(OBJS)
+	$(F90) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+
+clean:
+	rm -f $(PROG) $(OBJS) *.mod
+
+.f90.o:
+	$(F90) $(F90FLAGS) -c $< $(LIBS)
+
+$(OBJECT_PATH)main.o: $(OBJECT_PATH)options.o $(OBJECT_PATH)type_phasespacesurface.o
+	$(F90) $(F90FLAGS) -c main.f90 $(LIBS) -o $@
+$(OBJECT_PATH)options.o:
+	$(F90) $(F90FLAGS) -c options.f90 $(LIBS) -o $@
+$(OBJECT_PATH)type_phasespacesurface.o:
+	$(F90) $(F90FLAGS) -c type_phasespacesurface.f90 $(LIBS) -o $@

--- a/src/phasespace_surface/main.f90
+++ b/src/phasespace_surface/main.f90
@@ -51,30 +51,30 @@ endif
 
 ! Get a q-mesh
 if ( opts%readqmesh ) then
-    call lo_read_qmesh_from_file(qp,uc,'infile.qgrid.hdf5',verbosity=opts%verbosity)
+    call lo_read_qmesh_from_file(qp,uc,'infile.qgrid.hdf5',mem,verbosity=opts%verbosity)
     write(*,*) '... read mesh from file'
 else
     write(*,*) '... generate mesh'
-    call lo_generate_qmesh(qp,uc,opts%qgrid,'wedge',verbosity=opts%verbosity,timereversal=opts%timereversal,mw=mw)
+    call lo_generate_qmesh(qp,uc,opts%qgrid,'wedge',verbosity=opts%verbosity,timereversal=opts%timereversal,headrankonly=.true.,mw=mw,mem=mem)
 endif
 
 ! Get the actual q-point we are interested in
-qpoint%noperations=0
+qpoint%n_invariant_operation=0
 if ( trim(opts%highsymmetrypoint) .ne. 'none' ) then
-    qpoint%v=uc%coordinate_from_high_symmetry_point_label(opts%highsymmetrypoint)
+    qpoint%r=uc%coordinate_from_high_symmetry_point_label(opts%highsymmetrypoint)
 else
-    qpoint%v=uc%fractional_to_cartesian(opts%qpoint,reciprocal=.true.)
+    qpoint%r=uc%fractional_to_cartesian(opts%qpoint,reciprocal=.true.)
 endif
-qpoint%w=qpoint%v-uc%bz%gshift(qpoint%v)
+qpoint%r=qpoint%r-uc%bz%gshift(qpoint%r)
 
 ! Build the surfaces
 select type(qp)
 type is(lo_wedge_mesh)
     if ( opts%povray ) then
         call ps%generate(qp,uc,fc,fct,qpoint,opts%verbosity,opts%modespec,&
-                         calcintens=opts%intensities)
+                         calcintens=opts%intensities,mem=mem)
     else
-        call ps%generate(qp,uc,fc,fct,qpoint,opts%verbosity,calcintens=opts%intensities)
+        call ps%generate(qp,uc,fc,fct,qpoint,opts%verbosity,calcintens=opts%intensities,mem=mem)
     endif
 class default
     write(*,*) 'Unknown mesh type'

--- a/src/phasespace_surface/main.f90
+++ b/src/phasespace_surface/main.f90
@@ -74,7 +74,7 @@ type is (lo_wedge_mesh)
         call ps%generate(qp, uc, fc, fct, qpoint, opts%verbosity, opts%modespec, &
                          calcintens=opts%intensities, mem=mem)
     else
-        call ps%generate(qp, uc, fc, fct, qpoint, opts%verbosity, calcintens=opts%intensities, mem=mem)
+        call ps%generate(qp, uc, fc, fct, qpoint, opts%verbosity, calcintens=opts%intensities, mem=mem, nband=opts%nband)
     end if
 class default
     write (*, *) 'Unknown mesh type'

--- a/src/phasespace_surface/main.f90
+++ b/src/phasespace_surface/main.f90
@@ -85,7 +85,8 @@ end select
 if (opts%povray) then
     call ps%write_to_povray(uc, 'outfile.phasespacesurface', opts%thetaphi(1), opts%thetaphi(2), opts%modespec, opts%povrayquality)
 else
-    ! Dump it to file
+    ! Dump it to file, skip nonzero
+    print *, '... write nonzero phase spaces and scattering intensities'
     cnt: block
         integer :: b1, b2, b3
 
@@ -93,7 +94,9 @@ else
         do b1 = 1, uc%na*3
         do b2 = 1, uc%na*3
         do b3 = 1, uc%na*3
-            write (*, *) b1, b2, b3, ps%plus(b1, b2, b3)%ntri
+            if (ps%plus(b1, b2, b3)%ntri > 0) then
+                write (*, '(4I20, E20.10)') b1, b2, b3, ps%plus(b1, b2, b3)%ntri, ps%plus(b1, b2, b3)%psisquared_norm
+            end if
         end do
         end do
         end do
@@ -101,7 +104,9 @@ else
         do b1 = 1, uc%na*3
         do b2 = 1, uc%na*3
         do b3 = 1, uc%na*3
-            write (*, *) b1, b2, b3, ps%minus(b1, b2, b3)%ntri
+            if (ps%minus(b1, b2, b3)%ntri > 0) then
+                write (*, '(4I20, E20.10)') b1, b2, b3, ps%minus(b1, b2, b3)%ntri, ps%minus(b1, b2, b3)%psisquared_norm
+            end if
         end do
         end do
         end do

--- a/src/phasespace_surface/main.f90
+++ b/src/phasespace_surface/main.f90
@@ -1,17 +1,17 @@
 program phasespace_surface
-use konstanter, only: flyt,lo_status
-use gottochblandat, only: walltime,tochar
+use konstanter, only: flyt, lo_status
+use gottochblandat, only: walltime, tochar
 use mpi_wrappers, only: lo_mpi_helper
 use type_crystalstructure, only: lo_crystalstructure
 use type_forceconstant_secondorder, only: lo_forceconstant_secondorder
 use type_forceconstant_thirdorder, only: lo_forceconstant_thirdorder
-use type_qpointmesh, only: lo_qpoint_mesh,lo_wedge_mesh,lo_qpoint,lo_generate_qmesh,lo_read_qmesh_from_file
+use type_qpointmesh, only: lo_qpoint_mesh, lo_wedge_mesh, lo_qpoint, lo_generate_qmesh, lo_read_qmesh_from_file
 use type_phonon_dispersions, only: lo_phonon_dispersions
 
 use options, only: lo_opts
 use type_phasespacesurface, only: lo_phasespacesurface
 use lo_memtracker, only: lo_mem_helper
-! 
+!
 implicit none
 !
 type(lo_opts) :: opts
@@ -27,92 +27,89 @@ real(flyt) :: t0
 type(lo_mem_helper) :: mem
 
 call mw%init()
-t0=walltime()
+t0 = walltime()
 call opts%parse()
 call mem%init()
 
-
 ! Read unitcell
-write(*,*) '... read unitcell poscar'
+write (*, *) '... read unitcell poscar'
 call uc%readfromfile('infile.ucposcar')
 call uc%classify('wedge', timereversal=.true.)
-if ( opts%readiso ) then
-    write(*,*) '... reading isotope distribution from file'
+if (opts%readiso) then
+    write (*, *) '... reading isotope distribution from file'
     call uc%readisotopefromfile()
-endif
+end if
 
 ! Read the force constant
-call fc%readfromfile(uc,'infile.forceconstant',mem,opts%verbosity)
-write(*,*) '... read second order forceconstant'
+call fc%readfromfile(uc, 'infile.forceconstant', mem, opts%verbosity)
+write (*, *) '... read second order forceconstant'
 !if ( opts%thirdorder ) then
-if ( opts%intensities ) then
-    call fct%readfromfile(uc,'infile.forceconstant_thirdorder')
-    write(*,*) '... read third order forceconstant'
-endif
+if (opts%intensities) then
+    call fct%readfromfile(uc, 'infile.forceconstant_thirdorder')
+    write (*, *) '... read third order forceconstant'
+end if
 
 ! Get a q-mesh
-if ( opts%readqmesh ) then
-    call lo_read_qmesh_from_file(qp,uc,'infile.qgrid.hdf5',mem,verbosity=opts%verbosity)
-    write(*,*) '... read mesh from file'
+if (opts%readqmesh) then
+    call lo_read_qmesh_from_file(qp, uc, 'infile.qgrid.hdf5', mem, verbosity=opts%verbosity)
+    write (*, *) '... read mesh from file'
 else
-    write(*,*) '... generate mesh'
-    call lo_generate_qmesh(qp,uc,opts%qgrid,'wedge',verbosity=opts%verbosity,timereversal=opts%timereversal,headrankonly=.true.,mw=mw,mem=mem)
-endif
+    write (*, *) '... generate mesh'
+    call lo_generate_qmesh(qp, uc, opts%qgrid, 'wedge', verbosity=opts%verbosity, timereversal=opts%timereversal, headrankonly=.true., mw=mw, mem=mem)
+end if
 
 ! Get the actual q-point we are interested in
-qpoint%n_invariant_operation=0
-if ( trim(opts%highsymmetrypoint) .ne. 'none' ) then
-    qpoint%r=uc%coordinate_from_high_symmetry_point_label(opts%highsymmetrypoint)
+qpoint%n_invariant_operation = 0
+if (trim(opts%highsymmetrypoint) .ne. 'none') then
+    qpoint%r = uc%coordinate_from_high_symmetry_point_label(opts%highsymmetrypoint)
 else
-    qpoint%r=uc%fractional_to_cartesian(opts%qpoint,reciprocal=.true.)
-endif
-qpoint%r=qpoint%r-uc%bz%gshift(qpoint%r)
+    qpoint%r = uc%fractional_to_cartesian(opts%qpoint, reciprocal=.true.)
+end if
+qpoint%r = qpoint%r - uc%bz%gshift(qpoint%r)
 
 ! Build the surfaces
-select type(qp)
-type is(lo_wedge_mesh)
-    if ( opts%povray ) then
-        call ps%generate(qp,uc,fc,fct,qpoint,opts%verbosity,opts%modespec,&
-                         calcintens=opts%intensities,mem=mem)
+select type (qp)
+type is (lo_wedge_mesh)
+    if (opts%povray) then
+        call ps%generate(qp, uc, fc, fct, qpoint, opts%verbosity, opts%modespec, &
+                         calcintens=opts%intensities, mem=mem)
     else
-        call ps%generate(qp,uc,fc,fct,qpoint,opts%verbosity,calcintens=opts%intensities,mem=mem)
-    endif
+        call ps%generate(qp, uc, fc, fct, qpoint, opts%verbosity, calcintens=opts%intensities, mem=mem)
+    end if
 class default
-    write(*,*) 'Unknown mesh type'
+    write (*, *) 'Unknown mesh type'
     stop
 end select
 
-
 ! Also to a pov-ray file, if necessary!
-if ( opts%povray ) then
-    call ps%write_to_povray(uc,'outfile.phasespacesurface',opts%thetaphi(1),opts%thetaphi(2),opts%modespec,opts%povrayquality)
+if (opts%povray) then
+    call ps%write_to_povray(uc, 'outfile.phasespacesurface', opts%thetaphi(1), opts%thetaphi(2), opts%modespec, opts%povrayquality)
 else
     ! Dump it to file
-cnt: block
-    integer :: b1,b2,b3
+    cnt: block
+        integer :: b1, b2, b3
 
-    write(*,*) 'plus'
-    do b1=1,uc%na*3
-    do b2=1,uc%na*3
-    do b3=1,uc%na*3
-        write(*,*) b1,b2,b3,ps%plus(b1,b2,b3)%ntri
-    enddo
-    enddo
-    enddo
-    write(*,*) 'minus'
-    do b1=1,uc%na*3
-    do b2=1,uc%na*3
-    do b3=1,uc%na*3
-        write(*,*) b1,b2,b3,ps%minus(b1,b2,b3)%ntri
-    enddo
-    enddo
-    enddo
-end block cnt    
+        write (*, *) 'plus'
+        do b1 = 1, uc%na*3
+        do b2 = 1, uc%na*3
+        do b3 = 1, uc%na*3
+            write (*, *) b1, b2, b3, ps%plus(b1, b2, b3)%ntri
+        end do
+        end do
+        end do
+        write (*, *) 'minus'
+        do b1 = 1, uc%na*3
+        do b2 = 1, uc%na*3
+        do b3 = 1, uc%na*3
+            write (*, *) b1, b2, b3, ps%minus(b1, b2, b3)%ntri
+        end do
+        end do
+        end do
+    end block cnt
     !call ps%write_to_hdf5(uc,'outfile.phasespacesurface.hdf5')
-endif
+end if
 
-
-write(*,*) 'All done in ',tochar(walltime()-t0),'s'
+write (*, *) 'All done in ', tochar(walltime() - t0), 's'
 call mpi_finalize(lo_status)
 
 end program

--- a/src/phasespace_surface/main.f90
+++ b/src/phasespace_surface/main.f90
@@ -33,8 +33,9 @@ call mem%init()
 
 
 ! Read unitcell
-call uc%readfromfile('infile.ucposcar')
 write(*,*) '... read unitcell poscar'
+call uc%readfromfile('infile.ucposcar')
+call uc%classify('wedge', timereversal=.true.)
 if ( opts%readiso ) then
     write(*,*) '... reading isotope distribution from file'
     call uc%readisotopefromfile()

--- a/src/phasespace_surface/main.f90
+++ b/src/phasespace_surface/main.f90
@@ -1,0 +1,117 @@
+program phasespace_surface
+use konstanter, only: flyt,lo_status
+use gottochblandat, only: walltime,tochar
+use mpi_wrappers, only: lo_mpi_helper
+use type_crystalstructure, only: lo_crystalstructure
+use type_forceconstant_secondorder, only: lo_forceconstant_secondorder
+use type_forceconstant_thirdorder, only: lo_forceconstant_thirdorder
+use type_qpointmesh, only: lo_qpoint_mesh,lo_wedge_mesh,lo_qpoint,lo_generate_qmesh,lo_read_qmesh_from_file
+use type_phonon_dispersions, only: lo_phonon_dispersions
+
+use options, only: lo_opts
+use type_phasespacesurface, only: lo_phasespacesurface
+use lo_memtracker, only: lo_mem_helper
+! 
+implicit none
+!
+type(lo_opts) :: opts
+type(lo_forceconstant_secondorder) :: fc
+type(lo_forceconstant_thirdorder) :: fct
+type(lo_crystalstructure) :: uc
+class(lo_qpoint_mesh), allocatable :: qp
+type(lo_mpi_helper) :: mw
+!
+type(lo_phasespacesurface) :: ps
+type(lo_qpoint) :: qpoint
+real(flyt) :: t0
+type(lo_mem_helper) :: mem
+
+call mw%init()
+t0=walltime()
+call opts%parse()
+call mem%init()
+
+
+! Read unitcell
+call uc%readfromfile('infile.ucposcar')
+write(*,*) '... read unitcell poscar'
+if ( opts%readiso ) then
+    write(*,*) '... reading isotope distribution from file'
+    call uc%readisotopefromfile()
+endif
+
+! Read the force constant
+call fc%readfromfile(uc,'infile.forceconstant',mem,opts%verbosity)
+write(*,*) '... read second order forceconstant'
+!if ( opts%thirdorder ) then
+if ( opts%intensities ) then
+    call fct%readfromfile(uc,'infile.forceconstant_thirdorder')
+    write(*,*) '... read third order forceconstant'
+endif
+
+! Get a q-mesh
+if ( opts%readqmesh ) then
+    call lo_read_qmesh_from_file(qp,uc,'infile.qgrid.hdf5',verbosity=opts%verbosity)
+    write(*,*) '... read mesh from file'
+else
+    write(*,*) '... generate mesh'
+    call lo_generate_qmesh(qp,uc,opts%qgrid,'wedge',verbosity=opts%verbosity,timereversal=opts%timereversal,mw=mw)
+endif
+
+! Get the actual q-point we are interested in
+qpoint%noperations=0
+if ( trim(opts%highsymmetrypoint) .ne. 'none' ) then
+    qpoint%v=uc%coordinate_from_high_symmetry_point_label(opts%highsymmetrypoint)
+else
+    qpoint%v=uc%fractional_to_cartesian(opts%qpoint,reciprocal=.true.)
+endif
+qpoint%w=qpoint%v-uc%bz%gshift(qpoint%v)
+
+! Build the surfaces
+select type(qp)
+type is(lo_wedge_mesh)
+    if ( opts%povray ) then
+        call ps%generate(qp,uc,fc,fct,qpoint,opts%verbosity,opts%modespec,&
+                         calcintens=opts%intensities)
+    else
+        call ps%generate(qp,uc,fc,fct,qpoint,opts%verbosity,calcintens=opts%intensities)
+    endif
+class default
+    write(*,*) 'Unknown mesh type'
+    stop
+end select
+
+
+! Also to a pov-ray file, if necessary!
+if ( opts%povray ) then
+    call ps%write_to_povray(uc,'outfile.phasespacesurface',opts%thetaphi(1),opts%thetaphi(2),opts%modespec,opts%povrayquality)
+else
+    ! Dump it to file
+cnt: block
+    integer :: b1,b2,b3
+
+    write(*,*) 'plus'
+    do b1=1,uc%na*3
+    do b2=1,uc%na*3
+    do b3=1,uc%na*3
+        write(*,*) b1,b2,b3,ps%plus(b1,b2,b3)%ntri
+    enddo
+    enddo
+    enddo
+    write(*,*) 'minus'
+    do b1=1,uc%na*3
+    do b2=1,uc%na*3
+    do b3=1,uc%na*3
+        write(*,*) b1,b2,b3,ps%minus(b1,b2,b3)%ntri
+    enddo
+    enddo
+    enddo
+end block cnt    
+    !call ps%write_to_hdf5(uc,'outfile.phasespacesurface.hdf5')
+endif
+
+
+write(*,*) 'All done in ',tochar(walltime()-t0),'s'
+call mpi_finalize(lo_status)
+
+end program

--- a/src/phasespace_surface/options.f90
+++ b/src/phasespace_surface/options.f90
@@ -1,6 +1,6 @@
 #include "precompilerdefinitions"
 module options
-use konstanter, only: flyt,lo_status,lo_author,lo_licence,lo_version
+use konstanter, only: flyt, lo_status, lo_author, lo_licence, lo_version
 use flap, only: command_line_interface
 implicit none
 private
@@ -16,13 +16,13 @@ type lo_opts
     logical :: readqmesh
     logical :: povray
     logical :: timereversal
-    integer, dimension(:,:), allocatable :: modespec
+    integer, dimension(:, :), allocatable :: modespec
     integer :: nmodespec
     integer :: povrayquality
     logical :: intensities
     character(len=10) :: highsymmetrypoint
-    contains
-        procedure :: parse    
+contains
+    procedure :: parse
 end type
 
 contains
@@ -33,49 +33,49 @@ subroutine parse(opts)
     !> the helper parser
     type(command_line_interface) :: cli
     !
-    integer :: i,j,l,n
+    integer :: i, j, l, n
     integer, dimension(:), allocatable :: dumi
     logical :: dumlog
 
     ! basic info
-    call cli%init(progname    = 'phasespace_surface',&
-              authors     = lo_author,&
-              version     = lo_version,&
-              license     = lo_licence,&
-              help        = 'Usage: ',&
-              description = 'Calculate the three-phonon scattering surface.',&
-              examples    = ["phasespace_surface --highsymmetrypoint X  ",&
-                             "phasespace_surface --qpoint 0.1 0.2 0.3   "],&
-              epilog      = new_line('a')//"...")
-    ! 
-    call cli%add(switch='--qpoint',&
-        help='Specify the q-point for which to calculate the scattering surface.',&
-        nargs='3',required=.false.,act='store',def='0 0 0',error=lo_status)
-        if ( lo_status .ne. 0 ) stop
-    call cli%add(switch='--highsymmetrypoint',&
-        help='Same as above, but you can specify the label of a high-symmetry point instead, e.g. "X" or "L".',&
-        required=.false.,act='store',def='none',error=lo_status)
-        if ( lo_status .ne. 0 ) stop
-    call cli%add(switch='--modespec',&
-        help='Specify which surfaces to look at. 6 integers per surface: band1 band2 band3 plus/minus color opacity. Modes go from 1 to number of bands. plus/minus is 0 for plus events 1 for minus. Color from 1-3, opacity from 0-100.',&
-        nargs='+',required=.false.,act='store',def='1 2 3 0 1 100',error=lo_status)
-        if ( lo_status .ne. 0 ) stop
-    call cli%add(switch='--povray',&
-                help='Write POV-Ray script for rendering.',&
-                required=.false.,act='store_true',def='.false.',error=lo_status)
-                if ( lo_status .ne. 0 ) stop
-    call cli%add(switch='--intensities',&
-                help='Calculate intensities (matrix elements) as well.',&
-                required=.false.,act='store_true',def='.false.',error=lo_status)
-                if ( lo_status .ne. 0 ) stop
-    call cli%add(switch='--pv_theta_phi',&
-        help='Povray specification, theta and phi angles (in degrees) deteriming camera location.',&
-        nargs='2',required=.false.,act='store',def='20 30',error=lo_status)
-        if ( lo_status .ne. 0 ) stop
-    call cli%add(switch='--pv_quality',&
-        help='Povray rendering quality, 1-9 where 1 is worst.',&
-        required=.false.,act='store',def='9',error=lo_status)
-        if ( lo_status .ne. 0 ) stop
+    call cli%init(progname='phasespace_surface', &
+                  authors=lo_author, &
+                  version=lo_version, &
+                  license=lo_licence, &
+                  help='Usage: ', &
+                  description='Calculate the three-phonon scattering surface.', &
+                  examples=["phasespace_surface --highsymmetrypoint X  ", &
+                            "phasespace_surface --qpoint 0.1 0.2 0.3   "], &
+                  epilog=new_line('a')//"...")
+    !
+    call cli%add(switch='--qpoint', &
+                 help='Specify the q-point for which to calculate the scattering surface.', &
+                 nargs='3', required=.false., act='store', def='0 0 0', error=lo_status)
+    if (lo_status .ne. 0) stop
+    call cli%add(switch='--highsymmetrypoint', &
+                 help='Same as above, but you can specify the label of a high-symmetry point instead, e.g. "X" or "L".', &
+                 required=.false., act='store', def='none', error=lo_status)
+    if (lo_status .ne. 0) stop
+    call cli%add(switch='--modespec', &
+                 help='Specify which surfaces to look at. 6 integers per surface: band1 band2 band3 plus/minus color opacity. Modes go from 1 to number of bands. plus/minus is 0 for plus events 1 for minus. Color from 1-3, opacity from 0-100.', &
+                 nargs='+', required=.false., act='store', def='1 2 3 0 1 100', error=lo_status)
+    if (lo_status .ne. 0) stop
+    call cli%add(switch='--povray', &
+                 help='Write POV-Ray script for rendering.', &
+                 required=.false., act='store_true', def='.false.', error=lo_status)
+    if (lo_status .ne. 0) stop
+    call cli%add(switch='--intensities', &
+                 help='Calculate intensities (matrix elements) as well.', &
+                 required=.false., act='store_true', def='.false.', error=lo_status)
+    if (lo_status .ne. 0) stop
+    call cli%add(switch='--pv_theta_phi', &
+                 help='Povray specification, theta and phi angles (in degrees) deteriming camera location.', &
+                 nargs='2', required=.false., act='store', def='20 30', error=lo_status)
+    if (lo_status .ne. 0) stop
+    call cli%add(switch='--pv_quality', &
+                 help='Povray rendering quality, 1-9 where 1 is worst.', &
+                 required=.false., act='store', def='9', error=lo_status)
+    if (lo_status .ne. 0) stop
     cli_qpoint_grid
     cli_readqmesh
     cli_manpage
@@ -83,49 +83,49 @@ subroutine parse(opts)
 
     ! actually parse it
     call cli%parse(error=lo_status)
-    if ( lo_status .ne. 0 ) stop
+    if (lo_status .ne. 0) stop
     ! Should the manpage be generated? In that case, no point to go further than here.
-    dumlog=.false.
-    call cli%get(switch='--manpage',val=dumlog)
-    if ( dumlog ) then
+    dumlog = .false.
+    call cli%get(switch='--manpage', val=dumlog)
+    if (dumlog) then
         call cli%save_man_page(trim(cli%progname)//'.1')
         call cli%save_usage_to_markdown(trim(cli%progname)//'.md')
-        write(*,*) 'Wrote manpage for "'//trim(cli%progname)//'"'
+        write (*, *) 'Wrote manpage for "'//trim(cli%progname)//'"'
         stop
-    endif
-    call cli%get(switch='--verbose',val=dumlog); if ( dumlog ) opts%verbosity=2
+    end if
+    call cli%get(switch='--verbose', val=dumlog); if (dumlog) opts%verbosity = 2
     !
     ! get real options
-    call cli%get(switch='--qpoint_grid',val=opts%qgrid)
-    call cli%get(switch='--qpoint',val=opts%qpoint)
-    call cli%get(switch='--highsymmetrypoint',val=opts%highsymmetrypoint)
-    call cli%get(switch='--readqmesh',val=opts%readqmesh)
-    call cli%get(switch='--povray',val=opts%povray)
-    call cli%get(switch='--pv_theta_phi',val=opts%thetaphi)
-    call cli%get(switch='--pv_quality',val=opts%povrayquality)
-    call cli%get_varying(switch='--modespec',val=dumi)
-    call cli%get(switch='--intensities',val=opts%intensities)
+    call cli%get(switch='--qpoint_grid', val=opts%qgrid)
+    call cli%get(switch='--qpoint', val=opts%qpoint)
+    call cli%get(switch='--highsymmetrypoint', val=opts%highsymmetrypoint)
+    call cli%get(switch='--readqmesh', val=opts%readqmesh)
+    call cli%get(switch='--povray', val=opts%povray)
+    call cli%get(switch='--pv_theta_phi', val=opts%thetaphi)
+    call cli%get(switch='--pv_quality', val=opts%povrayquality)
+    call cli%get_varying(switch='--modespec', val=dumi)
+    call cli%get(switch='--intensities', val=opts%intensities)
 
     ! Clean up the mode specification thing right away
-    n=size(dumi,1) ! number of arguments
-    if ( mod(n,6) .ne. 0 ) then
-        write(*,*) 'Error: the mode specification must be done in multiples of 6 integers.'
+    n = size(dumi, 1) ! number of arguments
+    if (mod(n, 6) .ne. 0) then
+        write (*, *) 'Error: the mode specification must be done in multiples of 6 integers.'
         stop
-    endif
-    opts%nmodespec=n/6
-    lo_allocate(opts%modespec(6,opts%nmodespec))
-    opts%modespec=0
-    l=0
-    do i=1,opts%nmodespec
-    do j=1,6
-        l=l+1
-        opts%modespec(j,i)=dumi(l)
-    enddo
-    enddo
+    end if
+    opts%nmodespec = n/6
+    lo_allocate(opts%modespec(6, opts%nmodespec))
+    opts%modespec = 0
+    l = 0
+    do i = 1, opts%nmodespec
+    do j = 1, 6
+        l = l + 1
+        opts%modespec(j, i) = dumi(l)
+    end do
+    end do
 
-    opts%timereversal=.true.
-    opts%thirdorder=.false.
-    ! 
+    opts%timereversal = .true.
+    opts%thirdorder = .false.
+    !
 end subroutine
 
 end module

--- a/src/phasespace_surface/options.f90
+++ b/src/phasespace_surface/options.f90
@@ -20,6 +20,7 @@ type lo_opts
     integer :: nmodespec
     integer :: povrayquality
     logical :: intensities
+    integer :: nband
     character(len=10) :: highsymmetrypoint
 contains
     procedure :: parse
@@ -76,6 +77,10 @@ subroutine parse(opts)
                  help='Povray rendering quality, 1-9 where 1 is worst.', &
                  required=.false., act='store', def='9', error=lo_status)
     if (lo_status .ne. 0) stop
+    call cli%add(switch='--nband', &
+                 help='Specify first band index', &
+                 required=.false., act='store', def='-1', error=lo_status)
+    if (lo_status .ne. 0) stop
     cli_qpoint_grid
     cli_readqmesh
     cli_manpage
@@ -105,6 +110,7 @@ subroutine parse(opts)
     call cli%get(switch='--pv_quality', val=opts%povrayquality)
     call cli%get_varying(switch='--modespec', val=dumi)
     call cli%get(switch='--intensities', val=opts%intensities)
+    call cli%get(switch='--nband', val=opts%nband)
 
     ! Clean up the mode specification thing right away
     n = size(dumi, 1) ! number of arguments

--- a/src/phasespace_surface/options.f90
+++ b/src/phasespace_surface/options.f90
@@ -1,0 +1,131 @@
+#include "precompilerdefinitions"
+module options
+use konstanter, only: flyt,lo_status,lo_author,lo_licence,lo_version
+use flap, only: command_line_interface
+implicit none
+private
+public :: lo_opts
+
+type lo_opts
+    integer, dimension(3) :: qgrid
+    real(flyt), dimension(3) :: qpoint
+    real(flyt), dimension(2) :: thetaphi
+    logical :: readiso
+    integer :: verbosity
+    logical :: thirdorder
+    logical :: readqmesh
+    logical :: povray
+    logical :: timereversal
+    integer, dimension(:,:), allocatable :: modespec
+    integer :: nmodespec
+    integer :: povrayquality
+    logical :: intensities
+    character(len=10) :: highsymmetrypoint
+    contains
+        procedure :: parse    
+end type
+
+contains
+
+subroutine parse(opts)
+    !> the options
+    class(lo_opts), intent(out) :: opts
+    !> the helper parser
+    type(command_line_interface) :: cli
+    !
+    integer :: i,j,l,n
+    integer, dimension(:), allocatable :: dumi
+    logical :: dumlog
+
+    ! basic info
+    call cli%init(progname    = 'phasespace_surface',&
+              authors     = lo_author,&
+              version     = lo_version,&
+              license     = lo_licence,&
+              help        = 'Usage: ',&
+              description = 'Calculate the three-phonon scattering surface.',&
+              examples    = ["phasespace_surface --highsymmetrypoint X  ",&
+                             "phasespace_surface --qpoint 0.1 0.2 0.3   "],&
+              epilog      = new_line('a')//"...")
+    ! 
+    call cli%add(switch='--qpoint',&
+        help='Specify the q-point for which to calculate the scattering surface.',&
+        nargs='3',required=.false.,act='store',def='0 0 0',error=lo_status)
+        if ( lo_status .ne. 0 ) stop
+    call cli%add(switch='--highsymmetrypoint',&
+        help='Same as above, but you can specify the label of a high-symmetry point instead, e.g. "X" or "L".',&
+        required=.false.,act='store',def='none',error=lo_status)
+        if ( lo_status .ne. 0 ) stop
+    call cli%add(switch='--modespec',&
+        help='Specify which surfaces to look at. 6 integers per surface: band1 band2 band3 plus/minus color opacity. Modes go from 1 to number of bands. plus/minus is 0 for plus events 1 for minus. Color from 1-3, opacity from 0-100.',&
+        nargs='+',required=.false.,act='store',def='1 2 3 0 1 100',error=lo_status)
+        if ( lo_status .ne. 0 ) stop
+    call cli%add(switch='--povray',&
+                help='Write POV-Ray script for rendering.',&
+                required=.false.,act='store_true',def='.false.',error=lo_status)
+                if ( lo_status .ne. 0 ) stop
+    call cli%add(switch='--intensities',&
+                help='Calculate intensities (matrix elements) as well.',&
+                required=.false.,act='store_true',def='.false.',error=lo_status)
+                if ( lo_status .ne. 0 ) stop
+    call cli%add(switch='--pv_theta_phi',&
+        help='Povray specification, theta and phi angles (in degrees) deteriming camera location.',&
+        nargs='2',required=.false.,act='store',def='20 30',error=lo_status)
+        if ( lo_status .ne. 0 ) stop
+    call cli%add(switch='--pv_quality',&
+        help='Povray rendering quality, 1-9 where 1 is worst.',&
+        required=.false.,act='store',def='9',error=lo_status)
+        if ( lo_status .ne. 0 ) stop
+    cli_qpoint_grid
+    cli_readqmesh
+    cli_manpage
+    cli_verbose
+
+    ! actually parse it
+    call cli%parse(error=lo_status)
+    if ( lo_status .ne. 0 ) stop
+    ! Should the manpage be generated? In that case, no point to go further than here.
+    dumlog=.false.
+    call cli%get(switch='--manpage',val=dumlog)
+    if ( dumlog ) then
+        call cli%save_man_page(trim(cli%progname)//'.1')
+        call cli%save_usage_to_markdown(trim(cli%progname)//'.md')
+        write(*,*) 'Wrote manpage for "'//trim(cli%progname)//'"'
+        stop
+    endif
+    call cli%get(switch='--verbose',val=dumlog); if ( dumlog ) opts%verbosity=2
+    !
+    ! get real options
+    call cli%get(switch='--qpoint_grid',val=opts%qgrid)
+    call cli%get(switch='--qpoint',val=opts%qpoint)
+    call cli%get(switch='--highsymmetrypoint',val=opts%highsymmetrypoint)
+    call cli%get(switch='--readqmesh',val=opts%readqmesh)
+    call cli%get(switch='--povray',val=opts%povray)
+    call cli%get(switch='--pv_theta_phi',val=opts%thetaphi)
+    call cli%get(switch='--pv_quality',val=opts%povrayquality)
+    call cli%get_varying(switch='--modespec',val=dumi)
+    call cli%get(switch='--intensities',val=opts%intensities)
+
+    ! Clean up the mode specification thing right away
+    n=size(dumi,1) ! number of arguments
+    if ( mod(n,6) .ne. 0 ) then
+        write(*,*) 'Error: the mode specification must be done in multiples of 6 integers.'
+        stop
+    endif
+    opts%nmodespec=n/6
+    lo_allocate(opts%modespec(6,opts%nmodespec))
+    opts%modespec=0
+    l=0
+    do i=1,opts%nmodespec
+    do j=1,6
+        l=l+1
+        opts%modespec(j,i)=dumi(l)
+    enddo
+    enddo
+
+    opts%timereversal=.true.
+    opts%thirdorder=.false.
+    ! 
+end subroutine
+
+end module

--- a/src/phasespace_surface/type_phasespacesurface.f90
+++ b/src/phasespace_surface/type_phasespacesurface.f90
@@ -70,7 +70,7 @@ contains
 #include "type_phasespacesurface_povray.f90"
 
 !> generate three-phonon scattering surfaces
-subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens, mem)
+subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens, mem, nband)
     !> fermisurface
     class(lo_phasespacesurface), intent(out) :: ps
     !> qpoint mesh
@@ -90,6 +90,8 @@ subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens,
     !> calculate intensities (matrix elements)?
     logical, intent(in), optional :: calcintens
     type(lo_mem_helper), intent(inout) :: mem
+    !> optionally specify first band index
+    integer, intent(in), optional :: nband
     !
     integer :: i, j, k, l, u, ii, srf
     integer :: b1, b2, b3
@@ -117,8 +119,10 @@ subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens,
     do b3 = 1, ps%nb
         ps%plus(b1, b2, b3)%ntri = 0
         ps%plus(b1, b2, b3)%npts = 0
+        ps%plus(b1, b2, b3)%psisquared_norm = 0.0_flyt
         ps%minus(b1, b2, b3)%ntri = 0
         ps%minus(b1, b2, b3)%npts = 0
+        ps%minus(b1, b2, b3)%psisquared_norm = 0.0_flyt
     end do
     end do
     end do
@@ -174,6 +178,12 @@ subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens,
         l = 0
         call lo_progressbar_init()
         do b1 = 1, ps%nb
+        if (present(nband) .and. (nband > 0)) then
+            if (b1 .ne. nband) then
+                print *, '... nband = ', nband, ', skip b1 = ', b1
+                cycle
+            end if
+        end if
         do b2 = 1, ps%nb
         do b3 = 1, ps%nb
             ! get the isosurfaces

--- a/src/phasespace_surface/type_phasespacesurface.f90
+++ b/src/phasespace_surface/type_phasespacesurface.f90
@@ -1,0 +1,338 @@
+#include "precompilerdefinitions"
+module type_phasespacesurface
+use konstanter, only: flyt,lo_pi,lo_huge,lo_freqtol,lo_status,lo_sqtol,lo_twopi
+use gottochblandat, only: tochar,lo_cross,open_file,lo_signed_tetrahedron_volume,walltime,lo_sqnorm,&
+                   lo_progressbar_init,lo_progressbar,qsort
+use type_crystalstructure, only: lo_crystalstructure
+use type_forceconstant_secondorder, only: lo_forceconstant_secondorder
+use type_forceconstant_thirdorder, only: lo_forceconstant_thirdorder
+use type_phonon_dispersions, only: lo_phonon_dispersions,lo_phonon_dispersions_qpoint
+use type_qpointmesh, only: lo_qpoint_mesh,lo_wedge_mesh,lo_qpoint,lo_get_small_group_of_qpoint
+use hdf5_wrappers, only: lo_h5_store_data,lo_h5_store_attribute,HID_T,H5F_ACC_TRUNC_F,h5close_f,h5open_f,&
+                         h5fclose_f,h5fopen_f,h5fcreate_f,h5gclose_f,h5gopen_f,h5gcreate_f
+
+implicit none
+public :: lo_phasespacesurface
+
+type lo_phasespacesurface_patch
+    !> number of triangles
+    integer :: ntri
+    !> number of points
+    integer :: npts
+    !> the triangles
+    integer, dimension(:,:), allocatable :: tri
+    !> the points
+    real(flyt), dimension(:,:), allocatable :: pts
+    !> the gradient of e(k) over each triangle
+    real(flyt), dimension(:,:), allocatable :: grad
+    !> the matrix element (intensity) at each point
+    real(flyt), dimension(:), allocatable :: psisquared
+    !> the frequencies of the modes involved at each point (index: point, modelabel)
+    real(flyt), dimension(:,:), allocatable :: omega
+    !> the eigenvectors of the modes involved at each point (index: point, :, modelabel)
+    real(flyt), dimension(:,:,:), allocatable :: egv
+    !> the q-vectors of the modes involved at each point (index: point, :, modelabel)
+    real(flyt), dimension(:,:,:), allocatable :: q
+end type
+
+type lo_phasespacesurface
+    !> the energy of the isosurface
+    real(flyt) :: energy
+    !> how many bands are in this isosurface
+    integer :: nb
+    !> what are the global indices to these bands
+    integer, dimension(:), allocatable :: bandind
+    !> the actual surfaces
+    type(lo_phasespacesurface_patch), dimension(:,:,:), allocatable :: plus
+    type(lo_phasespacesurface_patch), dimension(:,:,:), allocatable :: minus
+    contains
+        !> build the fermisurface
+        procedure :: generate
+        !> dump it to file
+        procedure :: write_to_hdf5
+        !> dump it to povray
+        procedure :: write_to_povray
+end type
+
+!> helper type to get unique points
+type lo_points_in_boxes
+    integer :: n
+    integer, dimension(:), allocatable :: ind
+end type
+
+contains
+
+#include "type_phasespacesurface_cleanmesh.f90"
+#include "type_phasespacesurface_energycalculations.f90"
+#include "type_phasespacesurface_povray.f90"
+
+!> generate three-phonon scattering surfaces
+subroutine generate(ps,qp,uc,fc,fct,point,verbosity,modespec,calcintens)
+    !> fermisurface
+    class(lo_phasespacesurface), intent(out) :: ps
+    !> qpoint mesh
+    type(lo_wedge_mesh), intent(in) :: qp
+    !> unitcell
+    type(lo_crystalstructure), intent(in) :: uc
+    !> forceconstant
+    type(lo_forceconstant_secondorder), intent(inout) :: fc
+    !> thirdorder forceconstant
+    type(lo_forceconstant_thirdorder), intent(in) :: fct
+    !> the q-point in question
+    type(lo_qpoint), intent(in) :: point
+    !> how much to talk
+    integer, intent(in) :: verbosity
+    !> perhaps not all modes
+    integer, dimension(:,:), intent(in), optional :: modespec
+    !> calculate intensities (matrix elements)?
+    logical, intent(in), optional :: calcintens
+    !
+    integer :: i,j,k,l,u,ii,srf
+    integer :: b1,b2,b3
+    real(flyt), dimension(3,3) :: tripts
+    real(flyt), dimension(3) :: v0,v1,v2,v3
+    real(flyt) :: f0
+    real(flyt), dimension(:,:,:,:), allocatable :: energy_plus,energy_minus
+    logical :: calcintensities
+    !
+    if ( present(calcintens) ) then
+        calcintensities = calcintens
+    else
+        calcintensities = .false.
+    endif
+    !
+    if ( verbosity .gt. 0 ) write(*,*) ''
+    if ( verbosity .gt. 0 ) write(*,*) 'Calculating isosurfaces'
+    ps%nb=uc%na*3
+    lo_allocate(ps%plus(ps%nb,ps%nb,ps%nb))
+    lo_allocate(ps%minus(ps%nb,ps%nb,ps%nb))
+    lo_allocate(energy_plus(qp%nq_tot,ps%nb,ps%nb,ps%nb))
+    lo_allocate(energy_minus(qp%nq_tot,ps%nb,ps%nb,ps%nb))
+    do b1=1,ps%nb
+    do b2=1,ps%nb
+    do b3=1,ps%nb
+        ps%plus(b1,b2,b3)%ntri=0
+        ps%plus(b1,b2,b3)%npts=0
+        ps%minus(b1,b2,b3)%ntri=0
+        ps%minus(b1,b2,b3)%npts=0
+    enddo
+    enddo
+    enddo
+    if ( verbosity .gt. 0 ) write(*,*) '... made some initial space'
+      
+    ! Get the energy values     
+    call energy_values_on_vertices(point,qp,uc,fc,energy_plus,energy_minus)
+    if ( verbosity .gt. 0 ) write(*,*) '... got energies at nodes'
+
+    if ( present(modespec) ) then
+        ! Calculate only some surfaces
+        do srf=1,size(modespec,2)
+            write(*,*) 'building surface ',tochar(srf),' out of ',tochar(size(modespec,2))
+            b1=modespec(1,srf)
+            b2=modespec(2,srf)
+            b3=modespec(3,srf)
+            ii=modespec(4,srf)
+            ! get the isosurfaces
+            if ( ii .eq. 0 ) then
+                call bz_isosurface(qp,energy_plus(:,b1,b2,b3),0.0_flyt,ps%plus(b1,b2,b3)%pts,&
+                                   ps%plus(b1,b2,b3)%tri,ps%plus(b1,b2,b3)%grad,&
+                                   uc,fc,point,.true.,b1,b2,b3,verbosity=1,&
+                                   fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
+                                   tot_omega=ps%plus(b1,b2,b3)%omega,tot_egv=ps%plus(b1,b2,b3)%egv,&
+                                   tot_q=ps%plus(b1,b2,b3)%q)
+            else
+                call bz_isosurface(qp,energy_minus(:,b1,b2,b3),0.0_flyt,ps%minus(b1,b2,b3)%pts,&
+                                   ps%minus(b1,b2,b3)%tri,ps%minus(b1,b2,b3)%grad,&
+                                   uc,fc,point,.false.,b1,b2,b3,verbosity=1,&
+                                   fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
+                                   tot_omega=ps%minus(b1,b2,b3)%omega,tot_egv=ps%minus(b1,b2,b3)%egv,&
+                                   tot_q=ps%minus(b1,b2,b3)%q)
+            endif
+            if ( allocated(ps%plus(b1,b2,b3)%tri) ) then
+                ps%plus(b1,b2,b3)%ntri=size(ps%plus(b1,b2,b3)%tri,2)
+                ps%plus(b1,b2,b3)%npts=size(ps%plus(b1,b2,b3)%pts,2)
+            else
+                ps%plus(b1,b2,b3)%ntri=0
+                ps%plus(b1,b2,b3)%npts=0
+            endif
+            if ( allocated(ps%minus(b1,b2,b3)%tri) ) then
+                ps%minus(b1,b2,b3)%ntri=size(ps%minus(b1,b2,b3)%tri,2)
+                ps%minus(b1,b2,b3)%npts=size(ps%minus(b1,b2,b3)%pts,2)
+            else
+                ps%minus(b1,b2,b3)%ntri=0
+                ps%minus(b1,b2,b3)%npts=0
+            endif            
+        enddo
+    else
+        ! If not specified, calculate all the surfaces
+        l=0
+        call lo_progressbar_init()
+        do b1=1,ps%nb
+        do b2=1,ps%nb
+        do b3=1,ps%nb
+            ! get the isosurfaces
+            call bz_isosurface(qp,energy_plus(:,b1,b2,b3),0.0_flyt,ps%plus(b1,b2,b3)%pts,&
+                               ps%plus(b1,b2,b3)%tri,ps%plus(b1,b2,b3)%grad,&
+                               uc,fc,point,.true.,b1,b2,b3,&
+                               fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
+                               tot_omega=ps%plus(b1,b2,b3)%omega,tot_egv=ps%plus(b1,b2,b3)%egv,&
+                               tot_q=ps%plus(b1,b2,b3)%q)
+            call bz_isosurface(qp,energy_minus(:,b1,b2,b3),0.0_flyt,ps%minus(b1,b2,b3)%pts,&
+                               ps%minus(b1,b2,b3)%tri,ps%minus(b1,b2,b3)%grad,&
+                               uc,fc,point,.false.,b1,b2,b3,&
+                               fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
+                               tot_omega=ps%minus(b1,b2,b3)%omega,tot_egv=ps%minus(b1,b2,b3)%egv,&
+                               tot_q=ps%minus(b1,b2,b3)%q)
+            if ( allocated(ps%plus(b1,b2,b3)%tri) ) then
+                ps%plus(b1,b2,b3)%ntri=size(ps%plus(b1,b2,b3)%tri,2)
+                ps%plus(b1,b2,b3)%npts=size(ps%plus(b1,b2,b3)%pts,2)
+            else
+                ps%plus(b1,b2,b3)%ntri=0
+                ps%plus(b1,b2,b3)%npts=0
+            endif
+            if ( allocated(ps%minus(b1,b2,b3)%tri) ) then
+                ps%minus(b1,b2,b3)%ntri=size(ps%minus(b1,b2,b3)%tri,2)
+                ps%minus(b1,b2,b3)%npts=size(ps%minus(b1,b2,b3)%pts,2)
+            else
+                ps%minus(b1,b2,b3)%ntri=0
+                ps%minus(b1,b2,b3)%npts=0
+            endif
+            l=l+1
+            call lo_progressbar(' ... isosurfaces',l,ps%nb**3)
+        enddo
+        enddo
+        enddo
+    endif
+
+    if ( verbosity .gt. 0 ) write(*,*) '... got isosurfaces'
+
+    ! Align the triangles
+    do b1=1,ps%nb
+    do b2=1,ps%nb
+    do b3=1,ps%nb
+        v0=0.0_flyt
+        do i=1,ps%plus(b1,b2,b3)%npts
+            v0=v0+ps%plus(b1,b2,b3)%pts(:,i)/ps%plus(b1,b2,b3)%npts
+        enddo
+        do i=1,ps%plus(b1,b2,b3)%ntri
+            tripts=ps%plus(b1,b2,b3)%pts(:,ps%plus(b1,b2,b3)%tri(:,i))
+            v1=tripts(:,1)-tripts(:,3)
+            v2=tripts(:,2)-tripts(:,3)
+            v3=lo_cross(v1,v2)
+            !do j=1,3
+            !    v1(j)=sum(tripts(j,:))/3.0_flyt
+            !enddo
+            if ( dot_product(v3,v0) .lt. 0.0_flyt ) then
+                ps%plus(b1,b2,b3)%tri(:,i)=ps%plus(b1,b2,b3)%tri([3,2,1],i)
+            endif
+        enddo
+        v0=0.0_flyt
+        do i=1,ps%minus(b1,b2,b3)%npts
+            v0=v0+ps%minus(b1,b2,b3)%pts(:,i)/ps%minus(b1,b2,b3)%npts
+        enddo
+        do i=1,ps%minus(b1,b2,b3)%ntri
+            tripts=ps%minus(b1,b2,b3)%pts(:,ps%minus(b1,b2,b3)%tri(:,i))
+            v1=tripts(:,1)-tripts(:,3)
+            v2=tripts(:,2)-tripts(:,3)
+            v3=lo_cross(v1,v2)
+            !do j=1,3
+            !    v1(j)=sum(tripts(j,:))/3.0_flyt
+            !enddo
+            if ( dot_product(v3,v0) .lt. 0.0_flyt ) then
+                ps%minus(b1,b2,b3)%tri(:,i)=ps%minus(b1,b2,b3)%tri([3,2,1],i)
+            endif
+        enddo
+    enddo
+    enddo
+    enddo
+
+    if ( verbosity .gt. 0 ) write(*,*) '... got aligned triangles'
+    !
+end subroutine
+
+!> dump the surfaces as triangles
+subroutine write_to_hdf5(ps,uc,filename)
+    !> fermi surface
+    class(lo_phasespacesurface), intent(in) :: ps
+    !> unitcell
+    type(lo_crystalstructure), intent(in) :: uc
+    !> filename
+    character(len=*), intent(in) :: filename
+
+    integer :: i,j,k,np,nm
+    integer :: b1,b2,b3
+    integer(HID_T) :: file_id,group_id
+    character(len=1000) :: dum
+    !
+    write(*,*) ''
+    write(*,*) 'Writing surfaces to hdf5 file'
+    call h5open_f(lo_status); if ( lo_status .ne. 0 ) stop
+    call h5fcreate_f(trim(filename), H5F_ACC_TRUNC_F, file_id, lo_status); if ( lo_status .ne. 0 ) stop
+        ! store some metadata
+        call lo_h5_store_attribute(ps%nb,file_id,'number_of_bands')
+         do b1=1,ps%nb
+         do b2=1,ps%nb
+         do b3=1,ps%nb
+             np=ps%plus(b1,b2,b3)%ntri
+             dum='number_of_plus_triangles_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+             call lo_h5_store_attribute(np,file_id,trim(dum))
+             if ( np .gt. 0 ) then
+                 dum='triangles_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                 call lo_h5_store_data(ps%plus(b1,b2,b3)%tri,file_id,trim(dum))
+                 dum='points_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                 call lo_h5_store_data(ps%plus(b1,b2,b3)%pts,file_id,trim(dum))
+                 if ( any(ps%plus(b1,b2,b3)%psisquared .gt. 0.0_flyt) ) then
+                    dum='psisq_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%plus(b1,b2,b3)%psisquared,file_id,trim(dum))
+                    dum='omega_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%plus(b1,b2,b3)%omega,file_id,trim(dum))
+                    dum='egv_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%plus(b1,b2,b3)%egv,file_id,trim(dum))
+                    dum='q_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%plus(b1,b2,b3)%q,file_id,trim(dum))
+                endif
+             endif
+             nm=ps%minus(b1,b2,b3)%ntri
+             dum='number_of_minus_triangles_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+             call lo_h5_store_attribute(nm,file_id,trim(dum))
+             if ( nm .gt. 0 ) then
+                 dum='triangles_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                 call lo_h5_store_data(ps%minus(b1,b2,b3)%tri,file_id,trim(dum))
+                 dum='points_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                 call lo_h5_store_data(ps%minus(b1,b2,b3)%pts,file_id,trim(dum))
+                 if ( any(ps%plus(b1,b2,b3)%psisquared .gt. 0.0_flyt) ) then
+                    dum='psisq_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%minus(b1,b2,b3)%psisquared,file_id,trim(dum))
+                    dum='omega_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%minus(b1,b2,b3)%omega,file_id,trim(dum))
+                    dum='egv_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%minus(b1,b2,b3)%egv,file_id,trim(dum))
+                    dum='q_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                    call lo_h5_store_data(ps%minus(b1,b2,b3)%q,file_id,trim(dum))
+                endif
+             endif
+         enddo
+         enddo
+         enddo
+       ! create a group for the BZ
+        call h5gcreate_f(file_id,'brillouin_zone',group_id,lo_status)
+        if ( lo_status .ne. 0 ) then
+            write(*,*) '... error writing Brillouin zone'
+        endif
+            ! some meta
+            call lo_h5_store_attribute(uc%bz%nnodes,group_id,'number_of_nodes')
+            call lo_h5_store_attribute(uc%bz%nfaces,group_id,'number_of_faces')
+            ! store the nodes
+            call lo_h5_store_data(uc%bz%r,group_id,'nodes')
+            ! and the faces. Not the prettiest way, but it does not really matter.
+            do i=1,uc%bz%nfaces
+                dum='face_'//tochar(i)
+                call lo_h5_store_data(uc%bz%face(i)%ind,group_id,trim(dum))
+            enddo
+        call h5gclose_f(group_id,lo_status)
+    
+    call h5fclose_f(file_id, lo_status); if ( lo_status .ne. 0 ) stop
+    call h5close_f(lo_status); if ( lo_status .ne. 0 ) stop
+end subroutine
+
+end module

--- a/src/phasespace_surface/type_phasespacesurface.f90
+++ b/src/phasespace_surface/type_phasespacesurface.f90
@@ -28,6 +28,8 @@ type lo_phasespacesurface_patch
     real(flyt), dimension(:, :), allocatable :: grad
     !> the matrix element (intensity) at each point
     real(flyt), dimension(:), allocatable :: psisquared
+    !> the norm of matrix elements (intensity)
+    real(flyt) :: psisquared_norm
     !> the frequencies of the modes involved at each point (index: point, modelabel)
     real(flyt), dimension(:, :), allocatable :: omega
     !> the eigenvectors of the modes involved at each point (index: point, :, modelabel)
@@ -140,15 +142,17 @@ subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens,
                                    ps%plus(b1, b2, b3)%tri, ps%plus(b1, b2, b3)%grad, &
                                    uc, fc, point, .true., b1, b2, b3, verbosity=1, &
                                    fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                                   psisq_norm=ps%plus(b1, b2, b3)%psisquared_norm, &
                                    tot_omega=ps%plus(b1, b2, b3)%omega, tot_egv=ps%plus(b1, b2, b3)%egv, &
-                                   tot_q=ps%plus(b1, b2, b3)%q)
+                                   tot_q=ps%plus(b1, b2, b3)%q, mem=mem)
             else
                 call bz_isosurface(qp, energy_minus(:, b1, b2, b3), 0.0_flyt, ps%minus(b1, b2, b3)%pts, &
                                    ps%minus(b1, b2, b3)%tri, ps%minus(b1, b2, b3)%grad, &
                                    uc, fc, point, .false., b1, b2, b3, verbosity=1, &
                                    fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                                   psisq_norm=ps%minus(b1, b2, b3)%psisquared_norm, &
                                    tot_omega=ps%minus(b1, b2, b3)%omega, tot_egv=ps%minus(b1, b2, b3)%egv, &
-                                   tot_q=ps%minus(b1, b2, b3)%q)
+                                   tot_q=ps%minus(b1, b2, b3)%q, mem=mem)
             end if
             if (allocated(ps%plus(b1, b2, b3)%tri)) then
                 ps%plus(b1, b2, b3)%ntri = size(ps%plus(b1, b2, b3)%tri, 2)
@@ -177,14 +181,16 @@ subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens,
                                ps%plus(b1, b2, b3)%tri, ps%plus(b1, b2, b3)%grad, &
                                uc, fc, point, .true., b1, b2, b3, &
                                fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                               psisq_norm=ps%plus(b1, b2, b3)%psisquared_norm, &
                                tot_omega=ps%plus(b1, b2, b3)%omega, tot_egv=ps%plus(b1, b2, b3)%egv, &
-                               tot_q=ps%plus(b1, b2, b3)%q)
+                               tot_q=ps%plus(b1, b2, b3)%q, mem=mem)
             call bz_isosurface(qp, energy_minus(:, b1, b2, b3), 0.0_flyt, ps%minus(b1, b2, b3)%pts, &
                                ps%minus(b1, b2, b3)%tri, ps%minus(b1, b2, b3)%grad, &
                                uc, fc, point, .false., b1, b2, b3, &
                                fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                               psisq_norm=ps%minus(b1, b2, b3)%psisquared_norm, &
                                tot_omega=ps%minus(b1, b2, b3)%omega, tot_egv=ps%minus(b1, b2, b3)%egv, &
-                               tot_q=ps%minus(b1, b2, b3)%q)
+                               tot_q=ps%minus(b1, b2, b3)%q, mem=mem)
             if (allocated(ps%plus(b1, b2, b3)%tri)) then
                 ps%plus(b1, b2, b3)%ntri = size(ps%plus(b1, b2, b3)%tri, 2)
                 ps%plus(b1, b2, b3)%npts = size(ps%plus(b1, b2, b3)%pts, 2)

--- a/src/phasespace_surface/type_phasespacesurface.f90
+++ b/src/phasespace_surface/type_phasespacesurface.f90
@@ -1,16 +1,16 @@
 #include "precompilerdefinitions"
 module type_phasespacesurface
-use konstanter, only: flyt,lo_pi,lo_huge,lo_freqtol,lo_status,lo_sqtol,lo_twopi
-use gottochblandat, only: tochar,lo_cross,open_file,lo_signed_tetrahedron_volume,walltime,lo_sqnorm,&
-                   lo_progressbar_init,lo_progressbar,qsort
+use konstanter, only: flyt, lo_pi, lo_huge, lo_freqtol, lo_status, lo_sqtol, lo_twopi
+use gottochblandat, only: tochar, lo_cross, open_file, lo_signed_tetrahedron_volume, walltime, lo_sqnorm, &
+                          lo_progressbar_init, lo_progressbar, qsort
 use lo_memtracker, only: lo_mem_helper
 use type_crystalstructure, only: lo_crystalstructure
 use type_forceconstant_secondorder, only: lo_forceconstant_secondorder
 use type_forceconstant_thirdorder, only: lo_forceconstant_thirdorder
-use type_phonon_dispersions, only: lo_phonon_dispersions,lo_phonon_dispersions_qpoint
-use type_qpointmesh, only: lo_qpoint_mesh,lo_wedge_mesh,lo_qpoint,lo_get_small_group_of_qpoint
-use hdf5_wrappers, only: lo_h5_store_data,lo_h5_store_attribute,HID_T,H5F_ACC_TRUNC_F,h5close_f,h5open_f,&
-                         h5fclose_f,h5fopen_f,h5fcreate_f,h5gclose_f,h5gopen_f,h5gcreate_f
+use type_phonon_dispersions, only: lo_phonon_dispersions, lo_phonon_dispersions_qpoint
+use type_qpointmesh, only: lo_qpoint_mesh, lo_wedge_mesh, lo_qpoint, lo_get_small_group_of_qpoint
+use hdf5_wrappers, only: lo_h5_store_data, lo_h5_store_attribute, HID_T, H5F_ACC_TRUNC_F, h5close_f, h5open_f, &
+                         h5fclose_f, h5fopen_f, h5fcreate_f, h5gclose_f, h5gopen_f, h5gcreate_f
 
 implicit none
 public :: lo_phasespacesurface
@@ -21,19 +21,19 @@ type lo_phasespacesurface_patch
     !> number of points
     integer :: npts
     !> the triangles
-    integer, dimension(:,:), allocatable :: tri
+    integer, dimension(:, :), allocatable :: tri
     !> the points
-    real(flyt), dimension(:,:), allocatable :: pts
+    real(flyt), dimension(:, :), allocatable :: pts
     !> the gradient of e(k) over each triangle
-    real(flyt), dimension(:,:), allocatable :: grad
+    real(flyt), dimension(:, :), allocatable :: grad
     !> the matrix element (intensity) at each point
     real(flyt), dimension(:), allocatable :: psisquared
     !> the frequencies of the modes involved at each point (index: point, modelabel)
-    real(flyt), dimension(:,:), allocatable :: omega
+    real(flyt), dimension(:, :), allocatable :: omega
     !> the eigenvectors of the modes involved at each point (index: point, :, modelabel)
-    real(flyt), dimension(:,:,:), allocatable :: egv
+    real(flyt), dimension(:, :, :), allocatable :: egv
     !> the q-vectors of the modes involved at each point (index: point, :, modelabel)
-    real(flyt), dimension(:,:,:), allocatable :: q
+    real(flyt), dimension(:, :, :), allocatable :: q
 end type
 
 type lo_phasespacesurface
@@ -44,15 +44,15 @@ type lo_phasespacesurface
     !> what are the global indices to these bands
     integer, dimension(:), allocatable :: bandind
     !> the actual surfaces
-    type(lo_phasespacesurface_patch), dimension(:,:,:), allocatable :: plus
-    type(lo_phasespacesurface_patch), dimension(:,:,:), allocatable :: minus
-    contains
-        !> build the fermisurface
-        procedure :: generate
-        !> dump it to file
-        procedure :: write_to_hdf5
-        !> dump it to povray
-        procedure :: write_to_povray
+    type(lo_phasespacesurface_patch), dimension(:, :, :), allocatable :: plus
+    type(lo_phasespacesurface_patch), dimension(:, :, :), allocatable :: minus
+contains
+    !> build the fermisurface
+    procedure :: generate
+    !> dump it to file
+    procedure :: write_to_hdf5
+    !> dump it to povray
+    procedure :: write_to_povray
 end type
 
 !> helper type to get unique points
@@ -68,7 +68,7 @@ contains
 #include "type_phasespacesurface_povray.f90"
 
 !> generate three-phonon scattering surfaces
-subroutine generate(ps,qp,uc,fc,fct,point,verbosity,modespec,calcintens,mem)
+subroutine generate(ps, qp, uc, fc, fct, point, verbosity, modespec, calcintens, mem)
     !> fermisurface
     class(lo_phasespacesurface), intent(out) :: ps
     !> qpoint mesh
@@ -84,176 +84,176 @@ subroutine generate(ps,qp,uc,fc,fct,point,verbosity,modespec,calcintens,mem)
     !> how much to talk
     integer, intent(in) :: verbosity
     !> perhaps not all modes
-    integer, dimension(:,:), intent(in), optional :: modespec
+    integer, dimension(:, :), intent(in), optional :: modespec
     !> calculate intensities (matrix elements)?
     logical, intent(in), optional :: calcintens
     type(lo_mem_helper), intent(inout) :: mem
     !
-    integer :: i,j,k,l,u,ii,srf
-    integer :: b1,b2,b3
-    real(flyt), dimension(3,3) :: tripts
-    real(flyt), dimension(3) :: v0,v1,v2,v3
+    integer :: i, j, k, l, u, ii, srf
+    integer :: b1, b2, b3
+    real(flyt), dimension(3, 3) :: tripts
+    real(flyt), dimension(3) :: v0, v1, v2, v3
     real(flyt) :: f0
-    real(flyt), dimension(:,:,:,:), allocatable :: energy_plus,energy_minus
+    real(flyt), dimension(:, :, :, :), allocatable :: energy_plus, energy_minus
     logical :: calcintensities
     !
-    if ( present(calcintens) ) then
+    if (present(calcintens)) then
         calcintensities = calcintens
     else
         calcintensities = .false.
-    endif
+    end if
     !
-    if ( verbosity .gt. 0 ) write(*,*) ''
-    if ( verbosity .gt. 0 ) write(*,*) 'Calculating isosurfaces'
-    ps%nb=uc%na*3
-    lo_allocate(ps%plus(ps%nb,ps%nb,ps%nb))
-    lo_allocate(ps%minus(ps%nb,ps%nb,ps%nb))
-    lo_allocate(energy_plus(qp%n_full_point,ps%nb,ps%nb,ps%nb))
-    lo_allocate(energy_minus(qp%n_full_point,ps%nb,ps%nb,ps%nb))
-    do b1=1,ps%nb
-    do b2=1,ps%nb
-    do b3=1,ps%nb
-        ps%plus(b1,b2,b3)%ntri=0
-        ps%plus(b1,b2,b3)%npts=0
-        ps%minus(b1,b2,b3)%ntri=0
-        ps%minus(b1,b2,b3)%npts=0
-    enddo
-    enddo
-    enddo
-    if ( verbosity .gt. 0 ) write(*,*) '... made some initial space'
-      
-    ! Get the energy values     
-    call energy_values_on_vertices(point,qp,uc,fc,energy_plus,energy_minus,mem=mem)
-    if ( verbosity .gt. 0 ) write(*,*) '... got energies at nodes'
+    if (verbosity .gt. 0) write (*, *) ''
+    if (verbosity .gt. 0) write (*, *) 'Calculating isosurfaces'
+    ps%nb = uc%na*3
+    lo_allocate(ps%plus(ps%nb, ps%nb, ps%nb))
+    lo_allocate(ps%minus(ps%nb, ps%nb, ps%nb))
+    lo_allocate(energy_plus(qp%n_full_point, ps%nb, ps%nb, ps%nb))
+    lo_allocate(energy_minus(qp%n_full_point, ps%nb, ps%nb, ps%nb))
+    do b1 = 1, ps%nb
+    do b2 = 1, ps%nb
+    do b3 = 1, ps%nb
+        ps%plus(b1, b2, b3)%ntri = 0
+        ps%plus(b1, b2, b3)%npts = 0
+        ps%minus(b1, b2, b3)%ntri = 0
+        ps%minus(b1, b2, b3)%npts = 0
+    end do
+    end do
+    end do
+    if (verbosity .gt. 0) write (*, *) '... made some initial space'
 
-    if ( present(modespec) ) then
+    ! Get the energy values
+    call energy_values_on_vertices(point, qp, uc, fc, energy_plus, energy_minus, mem=mem)
+    if (verbosity .gt. 0) write (*, *) '... got energies at nodes'
+
+    if (present(modespec)) then
         ! Calculate only some surfaces
-        do srf=1,size(modespec,2)
-            write(*,*) 'building surface ',tochar(srf),' out of ',tochar(size(modespec,2))
-            b1=modespec(1,srf)
-            b2=modespec(2,srf)
-            b3=modespec(3,srf)
-            ii=modespec(4,srf)
+        do srf = 1, size(modespec, 2)
+            write (*, *) 'building surface ', tochar(srf), ' out of ', tochar(size(modespec, 2))
+            b1 = modespec(1, srf)
+            b2 = modespec(2, srf)
+            b3 = modespec(3, srf)
+            ii = modespec(4, srf)
             ! get the isosurfaces
-            if ( ii .eq. 0 ) then
-                call bz_isosurface(qp,energy_plus(:,b1,b2,b3),0.0_flyt,ps%plus(b1,b2,b3)%pts,&
-                                   ps%plus(b1,b2,b3)%tri,ps%plus(b1,b2,b3)%grad,&
-                                   uc,fc,point,.true.,b1,b2,b3,verbosity=1,&
-                                   fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
-                                   tot_omega=ps%plus(b1,b2,b3)%omega,tot_egv=ps%plus(b1,b2,b3)%egv,&
-                                   tot_q=ps%plus(b1,b2,b3)%q)
+            if (ii .eq. 0) then
+                call bz_isosurface(qp, energy_plus(:, b1, b2, b3), 0.0_flyt, ps%plus(b1, b2, b3)%pts, &
+                                   ps%plus(b1, b2, b3)%tri, ps%plus(b1, b2, b3)%grad, &
+                                   uc, fc, point, .true., b1, b2, b3, verbosity=1, &
+                                   fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                                   tot_omega=ps%plus(b1, b2, b3)%omega, tot_egv=ps%plus(b1, b2, b3)%egv, &
+                                   tot_q=ps%plus(b1, b2, b3)%q)
             else
-                call bz_isosurface(qp,energy_minus(:,b1,b2,b3),0.0_flyt,ps%minus(b1,b2,b3)%pts,&
-                                   ps%minus(b1,b2,b3)%tri,ps%minus(b1,b2,b3)%grad,&
-                                   uc,fc,point,.false.,b1,b2,b3,verbosity=1,&
-                                   fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
-                                   tot_omega=ps%minus(b1,b2,b3)%omega,tot_egv=ps%minus(b1,b2,b3)%egv,&
-                                   tot_q=ps%minus(b1,b2,b3)%q)
-            endif
-            if ( allocated(ps%plus(b1,b2,b3)%tri) ) then
-                ps%plus(b1,b2,b3)%ntri=size(ps%plus(b1,b2,b3)%tri,2)
-                ps%plus(b1,b2,b3)%npts=size(ps%plus(b1,b2,b3)%pts,2)
+                call bz_isosurface(qp, energy_minus(:, b1, b2, b3), 0.0_flyt, ps%minus(b1, b2, b3)%pts, &
+                                   ps%minus(b1, b2, b3)%tri, ps%minus(b1, b2, b3)%grad, &
+                                   uc, fc, point, .false., b1, b2, b3, verbosity=1, &
+                                   fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                                   tot_omega=ps%minus(b1, b2, b3)%omega, tot_egv=ps%minus(b1, b2, b3)%egv, &
+                                   tot_q=ps%minus(b1, b2, b3)%q)
+            end if
+            if (allocated(ps%plus(b1, b2, b3)%tri)) then
+                ps%plus(b1, b2, b3)%ntri = size(ps%plus(b1, b2, b3)%tri, 2)
+                ps%plus(b1, b2, b3)%npts = size(ps%plus(b1, b2, b3)%pts, 2)
             else
-                ps%plus(b1,b2,b3)%ntri=0
-                ps%plus(b1,b2,b3)%npts=0
-            endif
-            if ( allocated(ps%minus(b1,b2,b3)%tri) ) then
-                ps%minus(b1,b2,b3)%ntri=size(ps%minus(b1,b2,b3)%tri,2)
-                ps%minus(b1,b2,b3)%npts=size(ps%minus(b1,b2,b3)%pts,2)
+                ps%plus(b1, b2, b3)%ntri = 0
+                ps%plus(b1, b2, b3)%npts = 0
+            end if
+            if (allocated(ps%minus(b1, b2, b3)%tri)) then
+                ps%minus(b1, b2, b3)%ntri = size(ps%minus(b1, b2, b3)%tri, 2)
+                ps%minus(b1, b2, b3)%npts = size(ps%minus(b1, b2, b3)%pts, 2)
             else
-                ps%minus(b1,b2,b3)%ntri=0
-                ps%minus(b1,b2,b3)%npts=0
-            endif            
-        enddo
+                ps%minus(b1, b2, b3)%ntri = 0
+                ps%minus(b1, b2, b3)%npts = 0
+            end if
+        end do
     else
         ! If not specified, calculate all the surfaces
-        l=0
+        l = 0
         call lo_progressbar_init()
-        do b1=1,ps%nb
-        do b2=1,ps%nb
-        do b3=1,ps%nb
+        do b1 = 1, ps%nb
+        do b2 = 1, ps%nb
+        do b3 = 1, ps%nb
             ! get the isosurfaces
-            call bz_isosurface(qp,energy_plus(:,b1,b2,b3),0.0_flyt,ps%plus(b1,b2,b3)%pts,&
-                               ps%plus(b1,b2,b3)%tri,ps%plus(b1,b2,b3)%grad,&
-                               uc,fc,point,.true.,b1,b2,b3,&
-                               fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
-                               tot_omega=ps%plus(b1,b2,b3)%omega,tot_egv=ps%plus(b1,b2,b3)%egv,&
-                               tot_q=ps%plus(b1,b2,b3)%q)
-            call bz_isosurface(qp,energy_minus(:,b1,b2,b3),0.0_flyt,ps%minus(b1,b2,b3)%pts,&
-                               ps%minus(b1,b2,b3)%tri,ps%minus(b1,b2,b3)%grad,&
-                               uc,fc,point,.false.,b1,b2,b3,&
-                               fct=fct,calcintens=calcintensities,psisq=ps%plus(b1,b2,b3)%psisquared,&
-                               tot_omega=ps%minus(b1,b2,b3)%omega,tot_egv=ps%minus(b1,b2,b3)%egv,&
-                               tot_q=ps%minus(b1,b2,b3)%q)
-            if ( allocated(ps%plus(b1,b2,b3)%tri) ) then
-                ps%plus(b1,b2,b3)%ntri=size(ps%plus(b1,b2,b3)%tri,2)
-                ps%plus(b1,b2,b3)%npts=size(ps%plus(b1,b2,b3)%pts,2)
+            call bz_isosurface(qp, energy_plus(:, b1, b2, b3), 0.0_flyt, ps%plus(b1, b2, b3)%pts, &
+                               ps%plus(b1, b2, b3)%tri, ps%plus(b1, b2, b3)%grad, &
+                               uc, fc, point, .true., b1, b2, b3, &
+                               fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                               tot_omega=ps%plus(b1, b2, b3)%omega, tot_egv=ps%plus(b1, b2, b3)%egv, &
+                               tot_q=ps%plus(b1, b2, b3)%q)
+            call bz_isosurface(qp, energy_minus(:, b1, b2, b3), 0.0_flyt, ps%minus(b1, b2, b3)%pts, &
+                               ps%minus(b1, b2, b3)%tri, ps%minus(b1, b2, b3)%grad, &
+                               uc, fc, point, .false., b1, b2, b3, &
+                               fct=fct, calcintens=calcintensities, psisq=ps%plus(b1, b2, b3)%psisquared, &
+                               tot_omega=ps%minus(b1, b2, b3)%omega, tot_egv=ps%minus(b1, b2, b3)%egv, &
+                               tot_q=ps%minus(b1, b2, b3)%q)
+            if (allocated(ps%plus(b1, b2, b3)%tri)) then
+                ps%plus(b1, b2, b3)%ntri = size(ps%plus(b1, b2, b3)%tri, 2)
+                ps%plus(b1, b2, b3)%npts = size(ps%plus(b1, b2, b3)%pts, 2)
             else
-                ps%plus(b1,b2,b3)%ntri=0
-                ps%plus(b1,b2,b3)%npts=0
-            endif
-            if ( allocated(ps%minus(b1,b2,b3)%tri) ) then
-                ps%minus(b1,b2,b3)%ntri=size(ps%minus(b1,b2,b3)%tri,2)
-                ps%minus(b1,b2,b3)%npts=size(ps%minus(b1,b2,b3)%pts,2)
+                ps%plus(b1, b2, b3)%ntri = 0
+                ps%plus(b1, b2, b3)%npts = 0
+            end if
+            if (allocated(ps%minus(b1, b2, b3)%tri)) then
+                ps%minus(b1, b2, b3)%ntri = size(ps%minus(b1, b2, b3)%tri, 2)
+                ps%minus(b1, b2, b3)%npts = size(ps%minus(b1, b2, b3)%pts, 2)
             else
-                ps%minus(b1,b2,b3)%ntri=0
-                ps%minus(b1,b2,b3)%npts=0
-            endif
-            l=l+1
-            call lo_progressbar(' ... isosurfaces',l,ps%nb**3)
-        enddo
-        enddo
-        enddo
-    endif
+                ps%minus(b1, b2, b3)%ntri = 0
+                ps%minus(b1, b2, b3)%npts = 0
+            end if
+            l = l + 1
+            call lo_progressbar(' ... isosurfaces', l, ps%nb**3)
+        end do
+        end do
+        end do
+    end if
 
-    if ( verbosity .gt. 0 ) write(*,*) '... got isosurfaces'
+    if (verbosity .gt. 0) write (*, *) '... got isosurfaces'
 
     ! Align the triangles
-    do b1=1,ps%nb
-    do b2=1,ps%nb
-    do b3=1,ps%nb
-        v0=0.0_flyt
-        do i=1,ps%plus(b1,b2,b3)%npts
-            v0=v0+ps%plus(b1,b2,b3)%pts(:,i)/ps%plus(b1,b2,b3)%npts
-        enddo
-        do i=1,ps%plus(b1,b2,b3)%ntri
-            tripts=ps%plus(b1,b2,b3)%pts(:,ps%plus(b1,b2,b3)%tri(:,i))
-            v1=tripts(:,1)-tripts(:,3)
-            v2=tripts(:,2)-tripts(:,3)
-            v3=lo_cross(v1,v2)
+    do b1 = 1, ps%nb
+    do b2 = 1, ps%nb
+    do b3 = 1, ps%nb
+        v0 = 0.0_flyt
+        do i = 1, ps%plus(b1, b2, b3)%npts
+            v0 = v0 + ps%plus(b1, b2, b3)%pts(:, i)/ps%plus(b1, b2, b3)%npts
+        end do
+        do i = 1, ps%plus(b1, b2, b3)%ntri
+            tripts = ps%plus(b1, b2, b3)%pts(:, ps%plus(b1, b2, b3)%tri(:, i))
+            v1 = tripts(:, 1) - tripts(:, 3)
+            v2 = tripts(:, 2) - tripts(:, 3)
+            v3 = lo_cross(v1, v2)
             !do j=1,3
             !    v1(j)=sum(tripts(j,:))/3.0_flyt
             !enddo
-            if ( dot_product(v3,v0) .lt. 0.0_flyt ) then
-                ps%plus(b1,b2,b3)%tri(:,i)=ps%plus(b1,b2,b3)%tri([3,2,1],i)
-            endif
-        enddo
-        v0=0.0_flyt
-        do i=1,ps%minus(b1,b2,b3)%npts
-            v0=v0+ps%minus(b1,b2,b3)%pts(:,i)/ps%minus(b1,b2,b3)%npts
-        enddo
-        do i=1,ps%minus(b1,b2,b3)%ntri
-            tripts=ps%minus(b1,b2,b3)%pts(:,ps%minus(b1,b2,b3)%tri(:,i))
-            v1=tripts(:,1)-tripts(:,3)
-            v2=tripts(:,2)-tripts(:,3)
-            v3=lo_cross(v1,v2)
+            if (dot_product(v3, v0) .lt. 0.0_flyt) then
+                ps%plus(b1, b2, b3)%tri(:, i) = ps%plus(b1, b2, b3)%tri([3, 2, 1], i)
+            end if
+        end do
+        v0 = 0.0_flyt
+        do i = 1, ps%minus(b1, b2, b3)%npts
+            v0 = v0 + ps%minus(b1, b2, b3)%pts(:, i)/ps%minus(b1, b2, b3)%npts
+        end do
+        do i = 1, ps%minus(b1, b2, b3)%ntri
+            tripts = ps%minus(b1, b2, b3)%pts(:, ps%minus(b1, b2, b3)%tri(:, i))
+            v1 = tripts(:, 1) - tripts(:, 3)
+            v2 = tripts(:, 2) - tripts(:, 3)
+            v3 = lo_cross(v1, v2)
             !do j=1,3
             !    v1(j)=sum(tripts(j,:))/3.0_flyt
             !enddo
-            if ( dot_product(v3,v0) .lt. 0.0_flyt ) then
-                ps%minus(b1,b2,b3)%tri(:,i)=ps%minus(b1,b2,b3)%tri([3,2,1],i)
-            endif
-        enddo
-    enddo
-    enddo
-    enddo
+            if (dot_product(v3, v0) .lt. 0.0_flyt) then
+                ps%minus(b1, b2, b3)%tri(:, i) = ps%minus(b1, b2, b3)%tri([3, 2, 1], i)
+            end if
+        end do
+    end do
+    end do
+    end do
 
-    if ( verbosity .gt. 0 ) write(*,*) '... got aligned triangles'
+    if (verbosity .gt. 0) write (*, *) '... got aligned triangles'
     !
 end subroutine
 
 !> dump the surfaces as triangles
-subroutine write_to_hdf5(ps,uc,filename)
+subroutine write_to_hdf5(ps, uc, filename)
     !> fermi surface
     class(lo_phasespacesurface), intent(in) :: ps
     !> unitcell
@@ -261,80 +261,80 @@ subroutine write_to_hdf5(ps,uc,filename)
     !> filename
     character(len=*), intent(in) :: filename
 
-    integer :: i,j,k,np,nm
-    integer :: b1,b2,b3
-    integer(HID_T) :: file_id,group_id
+    integer :: i, j, k, np, nm
+    integer :: b1, b2, b3
+    integer(HID_T) :: file_id, group_id
     character(len=1000) :: dum
     !
-    write(*,*) ''
-    write(*,*) 'Writing surfaces to hdf5 file'
-    call h5open_f(lo_status); if ( lo_status .ne. 0 ) stop
-    call h5fcreate_f(trim(filename), H5F_ACC_TRUNC_F, file_id, lo_status); if ( lo_status .ne. 0 ) stop
-        ! store some metadata
-        call lo_h5_store_attribute(ps%nb,file_id,'number_of_bands')
-         do b1=1,ps%nb
-         do b2=1,ps%nb
-         do b3=1,ps%nb
-             np=ps%plus(b1,b2,b3)%ntri
-             dum='number_of_plus_triangles_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-             call lo_h5_store_attribute(np,file_id,trim(dum))
-             if ( np .gt. 0 ) then
-                 dum='triangles_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                 call lo_h5_store_data(ps%plus(b1,b2,b3)%tri,file_id,trim(dum))
-                 dum='points_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                 call lo_h5_store_data(ps%plus(b1,b2,b3)%pts,file_id,trim(dum))
-                 if ( any(ps%plus(b1,b2,b3)%psisquared .gt. 0.0_flyt) ) then
-                    dum='psisq_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%plus(b1,b2,b3)%psisquared,file_id,trim(dum))
-                    dum='omega_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%plus(b1,b2,b3)%omega,file_id,trim(dum))
-                    dum='egv_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%plus(b1,b2,b3)%egv,file_id,trim(dum))
-                    dum='q_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%plus(b1,b2,b3)%q,file_id,trim(dum))
-                endif
-             endif
-             nm=ps%minus(b1,b2,b3)%ntri
-             dum='number_of_minus_triangles_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-             call lo_h5_store_attribute(nm,file_id,trim(dum))
-             if ( nm .gt. 0 ) then
-                 dum='triangles_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                 call lo_h5_store_data(ps%minus(b1,b2,b3)%tri,file_id,trim(dum))
-                 dum='points_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                 call lo_h5_store_data(ps%minus(b1,b2,b3)%pts,file_id,trim(dum))
-                 if ( any(ps%plus(b1,b2,b3)%psisquared .gt. 0.0_flyt) ) then
-                    dum='psisq_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%minus(b1,b2,b3)%psisquared,file_id,trim(dum))
-                    dum='omega_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%minus(b1,b2,b3)%omega,file_id,trim(dum))
-                    dum='egv_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%minus(b1,b2,b3)%egv,file_id,trim(dum))
-                    dum='q_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
-                    call lo_h5_store_data(ps%minus(b1,b2,b3)%q,file_id,trim(dum))
-                endif
-             endif
-         enddo
-         enddo
-         enddo
-       ! create a group for the BZ
-        call h5gcreate_f(file_id,'brillouin_zone',group_id,lo_status)
-        if ( lo_status .ne. 0 ) then
-            write(*,*) '... error writing Brillouin zone'
-        endif
-            ! some meta
-            call lo_h5_store_attribute(uc%bz%nnodes,group_id,'number_of_nodes')
-            call lo_h5_store_attribute(uc%bz%nfaces,group_id,'number_of_faces')
-            ! store the nodes
-            call lo_h5_store_data(uc%bz%r,group_id,'nodes')
-            ! and the faces. Not the prettiest way, but it does not really matter.
-            do i=1,uc%bz%nfaces
-                dum='face_'//tochar(i)
-                call lo_h5_store_data(uc%bz%face(i)%ind,group_id,trim(dum))
-            enddo
-        call h5gclose_f(group_id,lo_status)
-    
-    call h5fclose_f(file_id, lo_status); if ( lo_status .ne. 0 ) stop
-    call h5close_f(lo_status); if ( lo_status .ne. 0 ) stop
+    write (*, *) ''
+    write (*, *) 'Writing surfaces to hdf5 file'
+    call h5open_f(lo_status); if (lo_status .ne. 0) stop
+    call h5fcreate_f(trim(filename), H5F_ACC_TRUNC_F, file_id, lo_status); if (lo_status .ne. 0) stop
+    ! store some metadata
+    call lo_h5_store_attribute(ps%nb, file_id, 'number_of_bands')
+    do b1 = 1, ps%nb
+    do b2 = 1, ps%nb
+    do b3 = 1, ps%nb
+        np = ps%plus(b1, b2, b3)%ntri
+        dum = 'number_of_plus_triangles_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+        call lo_h5_store_attribute(np, file_id, trim(dum))
+        if (np .gt. 0) then
+            dum = 'triangles_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+            call lo_h5_store_data(ps%plus(b1, b2, b3)%tri, file_id, trim(dum))
+            dum = 'points_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+            call lo_h5_store_data(ps%plus(b1, b2, b3)%pts, file_id, trim(dum))
+            if (any(ps%plus(b1, b2, b3)%psisquared .gt. 0.0_flyt)) then
+                dum = 'psisq_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%plus(b1, b2, b3)%psisquared, file_id, trim(dum))
+                dum = 'omega_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%plus(b1, b2, b3)%omega, file_id, trim(dum))
+                dum = 'egv_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%plus(b1, b2, b3)%egv, file_id, trim(dum))
+                dum = 'q_plus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%plus(b1, b2, b3)%q, file_id, trim(dum))
+            end if
+        end if
+        nm = ps%minus(b1, b2, b3)%ntri
+        dum = 'number_of_minus_triangles_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+        call lo_h5_store_attribute(nm, file_id, trim(dum))
+        if (nm .gt. 0) then
+            dum = 'triangles_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+            call lo_h5_store_data(ps%minus(b1, b2, b3)%tri, file_id, trim(dum))
+            dum = 'points_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+            call lo_h5_store_data(ps%minus(b1, b2, b3)%pts, file_id, trim(dum))
+            if (any(ps%plus(b1, b2, b3)%psisquared .gt. 0.0_flyt)) then
+                dum = 'psisq_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%minus(b1, b2, b3)%psisquared, file_id, trim(dum))
+                dum = 'omega_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%minus(b1, b2, b3)%omega, file_id, trim(dum))
+                dum = 'egv_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%minus(b1, b2, b3)%egv, file_id, trim(dum))
+                dum = 'q_minus_'//tochar(b1)//'_'//tochar(b2)//'_'//tochar(b3)
+                call lo_h5_store_data(ps%minus(b1, b2, b3)%q, file_id, trim(dum))
+            end if
+        end if
+    end do
+    end do
+    end do
+    ! create a group for the BZ
+    call h5gcreate_f(file_id, 'brillouin_zone', group_id, lo_status)
+    if (lo_status .ne. 0) then
+        write (*, *) '... error writing Brillouin zone'
+    end if
+    ! some meta
+    call lo_h5_store_attribute(uc%bz%nnodes, group_id, 'number_of_nodes')
+    call lo_h5_store_attribute(uc%bz%nfaces, group_id, 'number_of_faces')
+    ! store the nodes
+    call lo_h5_store_data(uc%bz%r, group_id, 'nodes')
+    ! and the faces. Not the prettiest way, but it does not really matter.
+    do i = 1, uc%bz%nfaces
+        dum = 'face_'//tochar(i)
+        call lo_h5_store_data(uc%bz%face(i)%ind, group_id, trim(dum))
+    end do
+    call h5gclose_f(group_id, lo_status)
+
+    call h5fclose_f(file_id, lo_status); if (lo_status .ne. 0) stop
+    call h5close_f(lo_status); if (lo_status .ne. 0) stop
 end subroutine
 
 end module

--- a/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
+++ b/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
@@ -1,6 +1,6 @@
 
 !> slice up the tetrahedrons
-subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1,b2,b3,verbosity,calcintens,fct,psisq,tot_omega,tot_egv,tot_q)
+subroutine bz_isosurface(qp, fvals, isoval, finr, fint, fingrad, uc, fc, qpoint1, plus, b1, b2, b3, verbosity, calcintens, fct, psisq, tot_omega, tot_egv, tot_q)
     !> the kpoint mesh
     type(lo_wedge_mesh), intent(in) :: qp
     !> the function values
@@ -8,17 +8,17 @@ subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1
     !> the isolevel
     real(flyt), intent(in) :: isoval
     !> the triangles
-    integer, dimension(:,:), allocatable, intent(out) :: fint
+    integer, dimension(:, :), allocatable, intent(out) :: fint
     !> the points
-    real(flyt), dimension(:,:), allocatable, intent(out) :: finr
+    real(flyt), dimension(:, :), allocatable, intent(out) :: finr
     !> the gradients
-    real(flyt), dimension(:,:), allocatable, intent(out) :: fingrad
+    real(flyt), dimension(:, :), allocatable, intent(out) :: fingrad
     !> to calculate the gradients
     type(lo_crystalstructure), intent(in) :: uc
     type(lo_forceconstant_secondorder), intent(inout) :: fc
     type(lo_qpoint), intent(in) :: qpoint1
     logical, intent(in) :: plus
-    integer, intent(in) :: b1,b2,b3
+    integer, intent(in) :: b1, b2, b3
     integer, intent(in), optional :: verbosity
     !> calculate intensities (matrix elements)?
     logical, intent(in), optional :: calcintens
@@ -27,252 +27,251 @@ subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1
     !> the 3-phonon matrix elements
     real(flyt), dimension(:), allocatable, intent(out), optional :: psisq
     !> the frequencies involved (index: point, modelabel)
-    real(flyt), dimension(:,:), allocatable, intent(out), optional :: tot_omega
+    real(flyt), dimension(:, :), allocatable, intent(out), optional :: tot_omega
     !> the eigenvectors and q-points involved (index: point, :, modelabel)
-    real(flyt), dimension(:,:,:), allocatable, intent(out), optional :: tot_egv,tot_q
+    real(flyt), dimension(:, :, :), allocatable, intent(out), optional :: tot_egv, tot_q
     !
-    integer, dimension(:,:), allocatable :: dumt
+    integer, dimension(:, :), allocatable :: dumt
     integer, dimension(:), allocatable :: ind !,dumind
-    integer, dimension(4) :: teti,sorti
-    integer :: i,j,k,l,ii,ll,ntri,nfintri
-    real(flyt), dimension(:,:), allocatable :: dumr
-    real(flyt), dimension(:,:), allocatable :: dumgrad
-    real(flyt), dimension(3,4) :: cpts
+    integer, dimension(4) :: teti, sorti
+    integer :: i, j, k, l, ii, ll, ntri, nfintri
+    real(flyt), dimension(:, :), allocatable :: dumr
+    real(flyt), dimension(:, :), allocatable :: dumgrad
+    real(flyt), dimension(3, 4) :: cpts
     real(flyt), dimension(4) :: tete
-    real(flyt), dimension(3) :: v0,v1,v2,v3,v4
-    real(flyt), dimension(3) :: r1,r2,r3,b
-    real(flyt) :: e21,e31,e41,e32,e42,e43
-    real(flyt) :: f0,f1,f2,f3,t0,tolerance
+    real(flyt), dimension(3) :: v0, v1, v2, v3, v4
+    real(flyt), dimension(3) :: r1, r2, r3, b
+    real(flyt) :: e21, e31, e41, e32, e42, e43
+    real(flyt) :: f0, f1, f2, f3, t0, tolerance
     logical :: verb
     !for matrix elements (intensities)
-    complex(flyt), dimension(fc%na*3,3) :: egv 
+    complex(flyt), dimension(fc%na*3, 3) :: egv
     complex(flyt) :: c0
-    real(flyt), dimension(3) :: q1,q2,q3,omega
+    real(flyt), dimension(3) :: q1, q2, q3, omega
     logical :: calcintensities
 
-    if ( present(verbosity) ) then
-        if ( verbosity .gt. 0 ) then
-            verb=.true.
+    if (present(verbosity)) then
+        if (verbosity .gt. 0) then
+            verb = .true.
         else
-            verb=.false.
-        endif
+            verb = .false.
+        end if
     else
-        verb=.false.
-    endif
-    if ( present(calcintens) ) then
+        verb = .false.
+    end if
+    if (present(calcintens)) then
         calcintensities = calcintens
     else
         calcintensities = .false.
-    endif
+    end if
     if (calcintensities) then
         !assert that third order force constants are included
-        if (.not. present(fct) ) then
-            write(*,*) "you must pass fct if calcintensities=.true."
+        if (.not. present(fct)) then
+            write (*, *) "you must pass fct if calcintensities=.true."
             stop
-        endif
-    endif
+        end if
+    end if
     ! Fetch the tetrahedron energies
     ! space for possible points
-    lo_allocate(dumr(3,qp%n_full_tet*4))
-    lo_allocate(dumt(3,qp%n_full_tet*4))
-    lo_allocate(dumgrad(3,qp%n_full_tet*4))
-    dumr=0.0_flyt
-    dumt=0
-    dumgrad=0.0_flyt
-    
-    tolerance=lo_freqtol
-    l=0
-    ll=0
-    if ( verb ) call lo_progressbar_init()
-    do i=1,qp%n_full_tet
+    lo_allocate(dumr(3, qp%n_full_tet*4))
+    lo_allocate(dumt(3, qp%n_full_tet*4))
+    lo_allocate(dumgrad(3, qp%n_full_tet*4))
+    dumr = 0.0_flyt
+    dumt = 0
+    dumgrad = 0.0_flyt
+
+    tolerance = lo_freqtol
+    l = 0
+    ll = 0
+    if (verb) call lo_progressbar_init()
+    do i = 1, qp%n_full_tet
         ! fetch energy at the corners, and coordinates
-        do j=1,4            
-            ii=qp%at(i)%full_index(j)
-            cpts(:,j)=qp%ap(ii)%r
-            tete(j)=fvals(ii)-isoval
-        enddo
-        sorti=sort_four_numbers(tete)
-        tete=tete(sorti)
-        cpts=cpts(:,sorti)
+        do j = 1, 4
+            ii = qp%at(i)%full_index(j)
+            cpts(:, j) = qp%ap(ii)%r
+            tete(j) = fvals(ii) - isoval
+        end do
+        sorti = sort_four_numbers(tete)
+        tete = tete(sorti)
+        cpts = cpts(:, sorti)
         ! cycle if outside bounds right away
-        if ( minval(tete) .gt. 0.0_flyt ) cycle
-        if ( maxval(tete) .lt. 0.0_flyt ) cycle
-        if ( sum(abs(tete)) .lt. lo_freqtol ) then
+        if (minval(tete) .gt. 0.0_flyt) cycle
+        if (maxval(tete) .lt. 0.0_flyt) cycle
+        if (sum(abs(tete)) .lt. lo_freqtol) then
             cycle
-        endif
+        end if
 
         ! Get the gradient, such that e(k)=e(1)+b.(k-k1) inside the tetrahedron
         ! Just the Lehman & Taut paper.
-        f0=-lo_signed_tetrahedron_volume(cpts)*6
-        v0=cpts(:,1)
-        v1=cpts(:,2)-v0
-        v2=cpts(:,3)-v0
-        v3=cpts(:,4)-v0
-        r1=lo_cross(v2,v3)/f0
-        r2=lo_cross(v3,v1)/f0
-        r3=lo_cross(v1,v2)/f0
-        b=0.0_flyt
-        b=b+(tete(2)-tete(1))*r1
-        b=b+(tete(3)-tete(1))*r2
-        b=b+(tete(4)-tete(1))*r3
-        b=b/norm2(b)
-        
+        f0 = -lo_signed_tetrahedron_volume(cpts)*6
+        v0 = cpts(:, 1)
+        v1 = cpts(:, 2) - v0
+        v2 = cpts(:, 3) - v0
+        v3 = cpts(:, 4) - v0
+        r1 = lo_cross(v2, v3)/f0
+        r2 = lo_cross(v3, v1)/f0
+        r3 = lo_cross(v1, v2)/f0
+        b = 0.0_flyt
+        b = b + (tete(2) - tete(1))*r1
+        b = b + (tete(3) - tete(1))*r2
+        b = b + (tete(4) - tete(1))*r3
+        b = b/norm2(b)
+
         ! Maybe catch degeneracies
-        e21=tete(2)-tete(1)
-        e31=tete(3)-tete(1)
-        e41=tete(4)-tete(1)
-        e32=tete(3)-tete(2)
-        e42=tete(4)-tete(2)
-        e43=tete(4)-tete(2)
-        
+        e21 = tete(2) - tete(1)
+        e31 = tete(3) - tete(1)
+        e41 = tete(4) - tete(1)
+        e32 = tete(3) - tete(2)
+        e42 = tete(4) - tete(2)
+        e43 = tete(4) - tete(2)
+
         ! Figure out if I'm going to do something.
-        if ( tete(1) .lt. 0.0_flyt .and. tete(2) .gt. 0.0_flyt ) then
+        if (tete(1) .lt. 0.0_flyt .and. tete(2) .gt. 0.0_flyt) then
             ! easy case!
-            v1=cpts(:,1)-tete(1)/(tete(3)-tete(1))*(cpts(:,3)-cpts(:,1))
-            v2=cpts(:,1)-tete(1)/(tete(4)-tete(1))*(cpts(:,4)-cpts(:,1))
-            v3=cpts(:,1)-tete(1)/(tete(2)-tete(1))*(cpts(:,2)-cpts(:,1))
+            v1 = cpts(:, 1) - tete(1)/(tete(3) - tete(1))*(cpts(:, 3) - cpts(:, 1))
+            v2 = cpts(:, 1) - tete(1)/(tete(4) - tete(1))*(cpts(:, 4) - cpts(:, 1))
+            v3 = cpts(:, 1) - tete(1)/(tete(2) - tete(1))*(cpts(:, 2) - cpts(:, 1))
             ! store
-            ll=ll+1
-            l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
-            l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
-            l=l+1; dumr(:,l)=v3; dumt(3,ll)=l; dumgrad(:,ll)=b
-        elseif ( tete(2) .lt. 0.0_flyt .and. tete(3) .gt. 0.0_flyt ) then
+            ll = ll + 1
+            l = l + 1; dumr(:, l) = v1; dumt(1, ll) = l; dumgrad(:, ll) = b
+            l = l + 1; dumr(:, l) = v2; dumt(2, ll) = l; dumgrad(:, ll) = b
+            l = l + 1; dumr(:, l) = v3; dumt(3, ll) = l; dumgrad(:, ll) = b
+        elseif (tete(2) .lt. 0.0_flyt .and. tete(3) .gt. 0.0_flyt) then
             ! annoying case
-            if ( abs(tete(3)-tete(1)) .gt. tolerance .and. &
-                 abs(tete(4)-tete(1)) .gt. tolerance .and. &
-                 abs(tete(4)-tete(2)) .gt. tolerance .and. &
-                 abs(tete(3)-tete(2)) .gt. tolerance ) then
-            
-            v1=cpts(:,1)-tete(1)/(e31)*(cpts(:,3)-cpts(:,1))
-            v2=cpts(:,1)-tete(1)/(e41)*(cpts(:,4)-cpts(:,1))
-            v3=cpts(:,2)-tete(2)/(e42)*(cpts(:,4)-cpts(:,2))
-            v4=cpts(:,2)-tete(2)/(e32)*(cpts(:,3)-cpts(:,2))
-            
-            ! Test building two triangles out of this, choose the pair
-            ! with as similar area as possible
-            f0=norm2( lo_cross(v2-v1,v4-v1) ) ! 124
-            f1=norm2( lo_cross(v4-v2,v3-v2) ) ! 324
-            !
-            f2=norm2( lo_cross(v3-v1,v2-v1) ) ! 132
-            f3=norm2( lo_cross(v2-v3,v4-v3) ) ! 134
-            !
-            if ( abs(f0-f1) .lt. abs(f3-f2) ) then
-                ! first case
-                ll=ll+1
-                l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v4; dumt(3,ll)=l; dumgrad(:,ll)=b
+            if (abs(tete(3) - tete(1)) .gt. tolerance .and. &
+                abs(tete(4) - tete(1)) .gt. tolerance .and. &
+                abs(tete(4) - tete(2)) .gt. tolerance .and. &
+                abs(tete(3) - tete(2)) .gt. tolerance) then
+
+                v1 = cpts(:, 1) - tete(1)/(e31)*(cpts(:, 3) - cpts(:, 1))
+                v2 = cpts(:, 1) - tete(1)/(e41)*(cpts(:, 4) - cpts(:, 1))
+                v3 = cpts(:, 2) - tete(2)/(e42)*(cpts(:, 4) - cpts(:, 2))
+                v4 = cpts(:, 2) - tete(2)/(e32)*(cpts(:, 3) - cpts(:, 2))
+
+                ! Test building two triangles out of this, choose the pair
+                ! with as similar area as possible
+                f0 = norm2(lo_cross(v2 - v1, v4 - v1)) ! 124
+                f1 = norm2(lo_cross(v4 - v2, v3 - v2)) ! 324
+                !
+                f2 = norm2(lo_cross(v3 - v1, v2 - v1)) ! 132
+                f3 = norm2(lo_cross(v2 - v3, v4 - v3)) ! 134
+                !
+                if (abs(f0 - f1) .lt. abs(f3 - f2)) then
+                    ! first case
+                    ll = ll + 1
+                    l = l + 1; dumr(:, l) = v1; dumt(1, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v2; dumt(2, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v4; dumt(3, ll) = l; dumgrad(:, ll) = b
 !                dumind(ll)=i
 
-                ll=ll+1
-                l=l+1; dumr(:,l)=v2; dumt(1,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v3; dumt(2,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v4; dumt(3,ll)=l; dumgrad(:,ll)=b
-            else
-                ! second
-                ll=ll+1
-                l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v3; dumt(3,ll)=l; dumgrad(:,ll)=b
-                !
-                ll=ll+1
-                l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v3; dumt(2,ll)=l; dumgrad(:,ll)=b
-                l=l+1; dumr(:,l)=v4; dumt(3,ll)=l; dumgrad(:,ll)=b
-            endif
-            endif
+                    ll = ll + 1
+                    l = l + 1; dumr(:, l) = v2; dumt(1, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v3; dumt(2, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v4; dumt(3, ll) = l; dumgrad(:, ll) = b
+                else
+                    ! second
+                    ll = ll + 1
+                    l = l + 1; dumr(:, l) = v1; dumt(1, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v2; dumt(2, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v3; dumt(3, ll) = l; dumgrad(:, ll) = b
+                    !
+                    ll = ll + 1
+                    l = l + 1; dumr(:, l) = v1; dumt(1, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v3; dumt(2, ll) = l; dumgrad(:, ll) = b
+                    l = l + 1; dumr(:, l) = v4; dumt(3, ll) = l; dumgrad(:, ll) = b
+                end if
+            end if
             !
-        elseif ( tete(3) .lt. 0.0_flyt .and. tete(4) .gt. 0.0_flyt ) then
+        elseif (tete(3) .lt. 0.0_flyt .and. tete(4) .gt. 0.0_flyt) then
             ! easy again!
-            v1=cpts(:,4)-tete(4)/(tete(2)-tete(4))*(cpts(:,2)-cpts(:,4))
-            v2=cpts(:,4)-tete(4)/(tete(1)-tete(4))*(cpts(:,1)-cpts(:,4))
-            v3=cpts(:,4)-tete(4)/(tete(3)-tete(4))*(cpts(:,3)-cpts(:,4))
+            v1 = cpts(:, 4) - tete(4)/(tete(2) - tete(4))*(cpts(:, 2) - cpts(:, 4))
+            v2 = cpts(:, 4) - tete(4)/(tete(1) - tete(4))*(cpts(:, 1) - cpts(:, 4))
+            v3 = cpts(:, 4) - tete(4)/(tete(3) - tete(4))*(cpts(:, 3) - cpts(:, 4))
             ! store
-            ll=ll+1
-            l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
-            l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
-            l=l+1; dumr(:,l)=v3; dumt(3,ll)=l; dumgrad(:,ll)=b
-        endif
+            ll = ll + 1
+            l = l + 1; dumr(:, l) = v1; dumt(1, ll) = l; dumgrad(:, ll) = b
+            l = l + 1; dumr(:, l) = v2; dumt(2, ll) = l; dumgrad(:, ll) = b
+            l = l + 1; dumr(:, l) = v3; dumt(3, ll) = l; dumgrad(:, ll) = b
+        end if
         !
-        if ( verb ) then
-            if ( mod(i,20) .eq. 0 ) then
-                call lo_progressbar(' ... building triangles',i,qp%n_full_tet)
-            endif
-        endif
-    enddo
-                
-    if ( verb ) call lo_progressbar(' ... building triangles',qp%n_full_tet,qp%n_full_tet)
+        if (verb) then
+            if (mod(i, 20) .eq. 0) then
+                call lo_progressbar(' ... building triangles', i, qp%n_full_tet)
+            end if
+        end if
+    end do
 
-    ! Stop if I found no points    
-    if ( l .eq. 0 ) return
+    if (verb) call lo_progressbar(' ... building triangles', qp%n_full_tet, qp%n_full_tet)
+
+    ! Stop if I found no points
+    if (l .eq. 0) return
 
     ! Add together gradients from triangles.
-    
-    
+
     ! Remove the redundant points. Do this twice, with two different sets of verlet boxes.
-    call remove_redundant_points(dumr(:,1:l),dumt(:,1:ll),finr,fint,6)
-    if ( size(finr,2) .lt. 3 ) then
+    call remove_redundant_points(dumr(:, 1:l), dumt(:, 1:ll), finr, fint, 6)
+    if (size(finr, 2) .lt. 3) then
         ! the reduction might remove all points
-        if ( allocated(finr) ) deallocate(finr)
-        if ( allocated(fint) ) deallocate(fint)
-        if ( allocated(fingrad) ) deallocate(fingrad)
+        if (allocated(finr)) deallocate (finr)
+        if (allocated(fint)) deallocate (fint)
+        if (allocated(fingrad)) deallocate (fingrad)
         return
-    endif
-    deallocate(dumr,dumt)
-    call remove_redundant_points(finr,fint,dumr,dumt,5)
-    deallocate(finr,fint)
-    if ( size(dumr,2) .lt. 3 ) then
+    end if
+    deallocate (dumr, dumt)
+    call remove_redundant_points(finr, fint, dumr, dumt, 5)
+    deallocate (finr, fint)
+    if (size(dumr, 2) .lt. 3) then
         ! the reduction might remove all points
         return
-    endif
-    
+    end if
+
     ! Remove the too tiny triangles.
-    ntri=ll
-    allocate(ind(ntri))
-    ind=1
+    ntri = ll
+    allocate (ind(ntri))
+    ind = 1
     ! find triangles with zero area
-    do i=1,ntri
+    do i = 1, ntri
         ! get the area of this triangle
-        v1=dumr(:,dumt(1,i))-dumr(:,dumt(3,i))
-        v2=dumr(:,dumt(2,i))-dumr(:,dumt(3,i))
-        if ( norm2(lo_cross(v1,v2)) .lt. lo_sqtol ) then
-            ind(i)=0
-        endif
-    enddo
-    
-    nfintri=sum(ind)
+        v1 = dumr(:, dumt(1, i)) - dumr(:, dumt(3, i))
+        v2 = dumr(:, dumt(2, i)) - dumr(:, dumt(3, i))
+        if (norm2(lo_cross(v1, v2)) .lt. lo_sqtol) then
+            ind(i) = 0
+        end if
+    end do
+
+    nfintri = sum(ind)
     ! make space for the nice things
-    allocate(finr(3,size(dumr,2)))
-    allocate(fingrad(3,nfintri))
-    allocate(fint(3,nfintri))
-    fingrad=0.0_flyt
-    fint=0
-    finr=0.0_flyt
-    l=0
-    do i=1,ntri
-        if ( ind(i) .eq. 1 ) then
-            l=l+1
-            fint(:,l)=dumt(:,i)
-            fingrad(:,l)=dumgrad(:,i)
-        endif
-    enddo
-    finr=dumr
+    allocate (finr(3, size(dumr, 2)))
+    allocate (fingrad(3, nfintri))
+    allocate (fint(3, nfintri))
+    fingrad = 0.0_flyt
+    fint = 0
+    finr = 0.0_flyt
+    l = 0
+    do i = 1, ntri
+        if (ind(i) .eq. 1) then
+            l = l + 1
+            fint(:, l) = dumt(:, i)
+            fingrad(:, l) = dumgrad(:, i)
+        end if
+    end do
+    finr = dumr
 
     ! Fix the gradients
-    dumr=0.0_flyt
-    do i=1,nfintri
-        do j=1,3
-            k=fint(j,i)
-            dumr(:,k)=dumr(:,k)+fingrad(:,i)
-        enddo
-    enddo
+    dumr = 0.0_flyt
+    do i = 1, nfintri
+        do j = 1, 3
+            k = fint(j, i)
+            dumr(:, k) = dumr(:, k) + fingrad(:, i)
+        end do
+    end do
     lo_deallocate(fingrad)
-    lo_allocate(fingrad(3,size(dumr,2)))
-    fingrad=dumr
+    lo_allocate(fingrad(3, size(dumr, 2)))
+    fingrad = dumr
 
-    do i=1,size(fingrad,2)
-        fingrad(:,i)=fingrad(:,i)/norm2(fingrad(:,i))
-    enddo
+    do i = 1, size(fingrad, 2)
+        fingrad(:, i) = fingrad(:, i)/norm2(fingrad(:, i))
+    end do
 
 !    fixgrad: block
 !        integer :: n,nb
@@ -356,7 +355,7 @@ subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1
 !                tot_q(i,:,2) = q2;
 !                tot_q(i,:,3) = q3;
 !            endif
-!        enddo 
+!        enddo
 !        if ( calcintens ) then
 !            call lo_progressbar(' ... calculating intensities',n,n)
 !        endif
@@ -371,225 +370,225 @@ pure function sort_four_numbers(n) result(ind)
     !> the output order so that n(ind) is sorted
     integer, dimension(4) :: ind
     !
-    integer :: low1,high1,low2,high2,highest,lowest,middle1,middle2
+    integer :: low1, high1, low2, high2, highest, lowest, middle1, middle2
     !
-    if ( n(1) <= n(2) ) then
+    if (n(1) <= n(2)) then
         low1 = 1
         high1 = 2
     else
         low1 = 2
         high1 = 1
-    endif
+    end if
 
-    if ( n(3) <= n(4) ) then
+    if (n(3) <= n(4)) then
         low2 = 3
         high2 = 4
     else
         low2 = 4
         high2 = 3
-    endif
+    end if
 
-    if ( n(low1) <= n(low2) ) then
+    if (n(low1) <= n(low2)) then
         lowest = low1
         middle1 = low2
     else
         lowest = low2
         middle1 = low1
-    endif
+    end if
 
-    if ( n(high1) >= n(high2) ) then
+    if (n(high1) >= n(high2)) then
         highest = high1
         middle2 = high2
     else
         highest = high2
         middle2 = high1
-    endif
+    end if
 
-    if ( n(middle1) < n(middle2) ) then
-        ind=(/lowest,middle1,middle2,highest/)
+    if (n(middle1) < n(middle2)) then
+        ind = (/lowest, middle1, middle2, highest/)
     else
-        ind=(/lowest,middle2,middle1,highest/)
-    endif
+        ind = (/lowest, middle2, middle1, highest/)
+    end if
     !
 end function
 
 !> use Verlet boxes to remove redundant points
-subroutine remove_redundant_points(r,tri,ur,utri,nb)
+subroutine remove_redundant_points(r, tri, ur, utri, nb)
     !> original points
-    real(flyt), dimension(:,:), intent(in) :: r
+    real(flyt), dimension(:, :), intent(in) :: r
     !> original triangles
-    integer, dimension(:,:), intent(in) :: tri
+    integer, dimension(:, :), intent(in) :: tri
     !> the unique points
-    real(flyt), dimension(:,:), allocatable, intent(out) :: ur
+    real(flyt), dimension(:, :), allocatable, intent(out) :: ur
     !> the new, fancy triangles
-    integer, dimension(:,:), allocatable, intent(out) :: utri
+    integer, dimension(:, :), allocatable, intent(out) :: utri
     !> number of boxes to use
     integer, intent(in) :: nb
     !
-    type(lo_points_in_boxes), dimension(:,:,:), allocatable :: b
-    integer(flyt), dimension(:), allocatable :: dumi,dumj,dumk
+    type(lo_points_in_boxes), dimension(:, :, :), allocatable :: b
+    integer(flyt), dimension(:), allocatable :: dumi, dumj, dumk
     integer, dimension(3) :: gi
-    integer :: i,j,k,l
-    integer :: np,ntri
+    integer :: i, j, k, l
+    integer :: np, ntri
     !
-    real(flyt), dimension(:,:), allocatable :: dum
-    real(flyt), dimension(3) :: minv,maxv,v1,v2
-    real(flyt) :: t0,t1
-    
+    real(flyt), dimension(:, :), allocatable :: dum
+    real(flyt), dimension(3) :: minv, maxv, v1, v2
+    real(flyt) :: t0, t1
+
     ! Get the boundaries of the box
-    t0=walltime()
-    np=size(r,2)
-    ntri=size(tri,2)
-    
+    t0 = walltime()
+    np = size(r, 2)
+    ntri = size(tri, 2)
+
     ! Get the box dimensions
-    minv=lo_huge
-    maxv=-lo_huge
-    do i=1,np
-        do j=1,3
-            minv(j)=min(r(j,i),minv(j))
-            maxv(j)=max(r(j,i),maxv(j))
-        enddo
-    enddo
+    minv = lo_huge
+    maxv = -lo_huge
+    do i = 1, np
+        do j = 1, 3
+            minv(j) = min(r(j, i), minv(j))
+            maxv(j) = max(r(j, i), maxv(j))
+        end do
+    end do
 
     ! It could be just a single point or something like that
-    if ( lo_sqnorm(minv-maxv) .lt. lo_sqtol ) then
-        lo_allocate(ur(3,1))
-        lo_allocate(utri(3,1))
-        ur=0.0_flyt
-        utri=0
+    if (lo_sqnorm(minv - maxv) .lt. lo_sqtol) then
+        lo_allocate(ur(3, 1))
+        lo_allocate(utri(3, 1))
+        ur = 0.0_flyt
+        utri = 0
         return
-    endif
+    end if
     ! pad it a little
-    minv=minv-abs(maxv-minv)*0.001_flyt
-    maxv=maxv+abs(maxv-minv)*0.001_flyt
-    
+    minv = minv - abs(maxv - minv)*0.001_flyt
+    maxv = maxv + abs(maxv - minv)*0.001_flyt
+
     ! Sort these into boxes, first reset the counter
-    allocate(b(nb,nb,nb))
-    do i=1,nb
-    do j=1,nb
-    do k=1,nb
-        b(i,j,k)%n=0
-    enddo
-    enddo
-    enddo
+    allocate (b(nb, nb, nb))
+    do i = 1, nb
+    do j = 1, nb
+    do k = 1, nb
+        b(i, j, k)%n = 0
+    end do
+    end do
+    end do
     ! Count particles per box
-    do i=1,np
-        gi=box_from_coordinates(r(:,i),minv,maxv,nb)
-        b(gi(1),gi(2),gi(3))%n=b(gi(1),gi(2),gi(3))%n+1
-    enddo
+    do i = 1, np
+        gi = box_from_coordinates(r(:, i), minv, maxv, nb)
+        b(gi(1), gi(2), gi(3))%n = b(gi(1), gi(2), gi(3))%n + 1
+    end do
     ! Make some space
-    l=0
-    do i=1,nb
-    do j=1,nb
-    do k=1,nb
-        if ( b(i,j,k)%n .gt. 0 ) then
-            l=l+b(i,j,k)%n
-            lo_allocate(b(i,j,k)%ind( b(i,j,k)%n ))
-        endif
-    enddo
-    enddo
-    enddo
+    l = 0
+    do i = 1, nb
+    do j = 1, nb
+    do k = 1, nb
+        if (b(i, j, k)%n .gt. 0) then
+            l = l + b(i, j, k)%n
+            lo_allocate(b(i, j, k)%ind(b(i, j, k)%n))
+        end if
+    end do
+    end do
+    end do
     ! Stuff the boxes
-    do i=1,nb
-    do j=1,nb
-    do k=1,nb
-        b(i,j,k)%n=0
-    enddo
-    enddo
-    enddo
-    do i=1,np
-        gi=box_from_coordinates(r(:,i),minv,maxv,nb)
-        b(gi(1),gi(2),gi(3))%n=b(gi(1),gi(2),gi(3))%n+1
-        b(gi(1),gi(2),gi(3))%ind( b(gi(1),gi(2),gi(3))%n )=i
-    enddo
-    
+    do i = 1, nb
+    do j = 1, nb
+    do k = 1, nb
+        b(i, j, k)%n = 0
+    end do
+    end do
+    end do
+    do i = 1, np
+        gi = box_from_coordinates(r(:, i), minv, maxv, nb)
+        b(gi(1), gi(2), gi(3))%n = b(gi(1), gi(2), gi(3))%n + 1
+        b(gi(1), gi(2), gi(3))%ind(b(gi(1), gi(2), gi(3))%n) = i
+    end do
+
     ! Find the unique
     lo_allocate(dumi(np))
     lo_allocate(dumj(np))
     lo_allocate(dumk(np))
-    lo_allocate(dum(3,np))
+    lo_allocate(dum(3, np))
     !
-    dumi=0
-    dumj=1
-    l=0
-    do i=1,np
+    dumi = 0
+    dumj = 1
+    l = 0
+    do i = 1, np
         ! Which box is it in?
-        gi=box_from_coordinates(r(:,i),minv,maxv,nb)
+        gi = box_from_coordinates(r(:, i), minv, maxv, nb)
         ! Compare with points in the same box
-        l=0
-        do j=1,b(gi(1),gi(2),gi(3))%n
-            k=b(gi(1),gi(2),gi(3))%ind(j)
-            if ( k .gt. i ) then
-                if ( lo_sqnorm(r(:,i)-r(:,k)) .lt. lo_sqtol ) then
-                    l=l+1
-                    dumj(k)=0
-                    dumi(k)=i
-                endif
-            endif
-        enddo
+        l = 0
+        do j = 1, b(gi(1), gi(2), gi(3))%n
+            k = b(gi(1), gi(2), gi(3))%ind(j)
+            if (k .gt. i) then
+                if (lo_sqnorm(r(:, i) - r(:, k)) .lt. lo_sqtol) then
+                    l = l + 1
+                    dumj(k) = 0
+                    dumi(k) = i
+                end if
+            end if
+        end do
         !
-    enddo
-    
+    end do
+
     ! Figure out the mapping
-    l=sum(dumj)
-    lo_allocate(ur(3,l))
-    j=0
-    dumk=0
-    do i=1,np
-        if ( dumj(i) .eq. 1 ) then
-            j=j+1
-            ur(:,j)=r(:,i)
-            dumk(i)=j
-        endif
-    enddo
-    
+    l = sum(dumj)
+    lo_allocate(ur(3, l))
+    j = 0
+    dumk = 0
+    do i = 1, np
+        if (dumj(i) .eq. 1) then
+            j = j + 1
+            ur(:, j) = r(:, i)
+            dumk(i) = j
+        end if
+    end do
+
     ! And the mapping for the redundant points
-    do i=1,np
-        if ( dumk(i) .eq. 0 ) then
-            j=i
+    do i = 1, np
+        if (dumk(i) .eq. 0) then
+            j = i
             do
-                j=dumi(j)
-                k=dumk(j)
-                if ( k .ne. 0 ) exit
-            enddo
-            dumk(i)=k
-        endif
-    enddo
-    
+                j = dumi(j)
+                k = dumk(j)
+                if (k .ne. 0) exit
+            end do
+            dumk(i) = k
+        end if
+    end do
+
     ! and the triangles
-    lo_allocate(utri(3,ntri))
-    do i=1,ntri
-        do j=1,3
-            utri(j,i)=dumk( tri(j,i) )
-        enddo
-    enddo
-    
+    lo_allocate(utri(3, ntri))
+    do i = 1, ntri
+        do j = 1, 3
+            utri(j, i) = dumk(tri(j, i))
+        end do
+    end do
+
     ! and some cleanup
     lo_deallocate(dum)
     lo_deallocate(dumi)
     lo_deallocate(dumj)
-    do i=1,nb
-    do j=1,nb
-    do k=1,nb
-        if ( b(i,j,k)%n .gt. 0 ) then
-            lo_deallocate(b(i,j,k)%ind)
-        endif
-    enddo
-    enddo
-    enddo
+    do i = 1, nb
+    do j = 1, nb
+    do k = 1, nb
+        if (b(i, j, k)%n .gt. 0) then
+            lo_deallocate(b(i, j, k)%ind)
+        end if
+    end do
+    end do
+    end do
     lo_deallocate(b)
-    contains
+contains
 
-    function box_from_coordinates(r,minv,maxv,nb) result(gi)
-        real(flyt), dimension(3), intent(in) :: r,minv,maxv
+    function box_from_coordinates(r, minv, maxv, nb) result(gi)
+        real(flyt), dimension(3), intent(in) :: r, minv, maxv
         integer, intent(in) :: nb
         integer, dimension(3) :: gi
         !
         integer :: i
         !
-        do i=1,3
-            gi(i)=floor(nb*(r(i)-minv(i))/(maxv(i)-minv(i)))+1
-        enddo
+        do i = 1, 3
+            gi(i) = floor(nb*(r(i) - minv(i))/(maxv(i) - minv(i))) + 1
+        end do
     end function
 
 end subroutine

--- a/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
+++ b/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
@@ -84,7 +84,6 @@ subroutine bz_isosurface(qp, fvals, isoval, finr, fint, fingrad, uc, fc, qpoint1
     dumr = 0.0_flyt
     dumt = 0
     dumgrad = 0.0_flyt
-    psisq_norm = 0.0_flyt
 
     tolerance = lo_freqtol
     l = 0

--- a/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
+++ b/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
@@ -1,0 +1,596 @@
+
+!> slice up the tetrahedrons
+subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1,b2,b3,verbosity,calcintens,fct,psisq,tot_omega,tot_egv,tot_q)
+    !> the kpoint mesh
+    type(lo_wedge_mesh), intent(in) :: qp
+    !> the function values
+    real(flyt), dimension(:), intent(in) :: fvals
+    !> the isolevel
+    real(flyt), intent(in) :: isoval
+    !> the triangles
+    integer, dimension(:,:), allocatable, intent(out) :: fint
+    !> the points
+    real(flyt), dimension(:,:), allocatable, intent(out) :: finr
+    !> the gradients
+    real(flyt), dimension(:,:), allocatable, intent(out) :: fingrad
+    !> to calculate the gradients
+    type(lo_crystalstructure), intent(in) :: uc
+    type(lo_forceconstant_secondorder), intent(inout) :: fc
+    type(lo_qpoint), intent(in) :: qpoint1
+    logical, intent(in) :: plus
+    integer, intent(in) :: b1,b2,b3
+    integer, intent(in), optional :: verbosity
+    !> calculate intensities (matrix elements)?
+    logical, intent(in), optional :: calcintens
+    !> third order force constants (for matrix elements)
+    type(lo_forceconstant_thirdorder), intent(in), optional :: fct
+    !> the 3-phonon matrix elements
+    real(flyt), dimension(:), allocatable, intent(out), optional :: psisq
+    !> the frequencies involved (index: point, modelabel)
+    real(flyt), dimension(:,:), allocatable, intent(out), optional :: tot_omega
+    !> the eigenvectors and q-points involved (index: point, :, modelabel)
+    real(flyt), dimension(:,:,:), allocatable, intent(out), optional :: tot_egv,tot_q
+    !
+    integer, dimension(:,:), allocatable :: dumt
+    integer, dimension(:), allocatable :: ind !,dumind
+    integer, dimension(4) :: teti,sorti
+    integer :: i,j,k,l,ii,ll,ntri,nfintri
+    real(flyt), dimension(:,:), allocatable :: dumr
+    real(flyt), dimension(:,:), allocatable :: dumgrad
+    real(flyt), dimension(3,4) :: cpts
+    real(flyt), dimension(4) :: tete
+    real(flyt), dimension(3) :: v0,v1,v2,v3,v4
+    real(flyt), dimension(3) :: r1,r2,r3,b
+    real(flyt) :: e21,e31,e41,e32,e42,e43
+    real(flyt) :: f0,f1,f2,f3,t0,tolerance
+    logical :: verb
+    !for matrix elements (intensities)
+    complex(flyt), dimension(fc%na*3,3) :: egv 
+    complex(flyt) :: c0
+    real(flyt), dimension(3) :: q1,q2,q3,omega
+    logical :: calcintensities
+
+    if ( present(verbosity) ) then
+        if ( verbosity .gt. 0 ) then
+            verb=.true.
+        else
+            verb=.false.
+        endif
+    else
+        verb=.false.
+    endif
+    if ( present(calcintens) ) then
+        calcintensities = calcintens
+    else
+        calcintensities = .false.
+    endif
+    if (calcintensities) then
+        !assert that third order force constants are included
+        if (.not. present(fct) ) then
+            write(*,*) "you must pass fct if calcintensities=.true."
+            stop
+        endif
+    endif
+    ! Fetch the tetrahedron energies
+    ! space for possible points
+    lo_allocate(dumr(3,qp%ntet_tot*4))
+    lo_allocate(dumt(3,qp%ntet_tot*4))
+    lo_allocate(dumgrad(3,qp%ntet_tot*4))
+    dumr=0.0_flyt
+    dumt=0
+    dumgrad=0.0_flyt
+    
+    tolerance=lo_freqtol
+    l=0
+    ll=0
+    if ( verb ) call lo_progressbar_init()
+    do i=1,qp%ntet_tot
+        ! fetch energy at the corners, and coordinates
+        do j=1,4            
+            ii=qp%atet(i)%gridind(j)
+            cpts(:,j)=qp%ap(ii)%w
+            tete(j)=fvals(ii)-isoval
+        enddo
+        sorti=sort_four_numbers(tete)
+        tete=tete(sorti)
+        cpts=cpts(:,sorti)
+        ! cycle if outside bounds right away
+        if ( minval(tete) .gt. 0.0_flyt ) cycle
+        if ( maxval(tete) .lt. 0.0_flyt ) cycle
+        if ( sum(abs(tete)) .lt. lo_freqtol ) then
+            cycle
+        endif
+
+        ! Get the gradient, such that e(k)=e(1)+b.(k-k1) inside the tetrahedron
+        ! Just the Lehman & Taut paper.
+        f0=-lo_signed_tetrahedron_volume(cpts)*6
+        v0=cpts(:,1)
+        v1=cpts(:,2)-v0
+        v2=cpts(:,3)-v0
+        v3=cpts(:,4)-v0
+        r1=lo_cross(v2,v3)/f0
+        r2=lo_cross(v3,v1)/f0
+        r3=lo_cross(v1,v2)/f0
+        b=0.0_flyt
+        b=b+(tete(2)-tete(1))*r1
+        b=b+(tete(3)-tete(1))*r2
+        b=b+(tete(4)-tete(1))*r3
+        b=b/norm2(b)
+        
+        ! Maybe catch degeneracies
+        e21=tete(2)-tete(1)
+        e31=tete(3)-tete(1)
+        e41=tete(4)-tete(1)
+        e32=tete(3)-tete(2)
+        e42=tete(4)-tete(2)
+        e43=tete(4)-tete(2)
+        
+        ! Figure out if I'm going to do something.
+        if ( tete(1) .lt. 0.0_flyt .and. tete(2) .gt. 0.0_flyt ) then
+            ! easy case!
+            v1=cpts(:,1)-tete(1)/(tete(3)-tete(1))*(cpts(:,3)-cpts(:,1))
+            v2=cpts(:,1)-tete(1)/(tete(4)-tete(1))*(cpts(:,4)-cpts(:,1))
+            v3=cpts(:,1)-tete(1)/(tete(2)-tete(1))*(cpts(:,2)-cpts(:,1))
+            ! store
+            ll=ll+1
+            l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
+            l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
+            l=l+1; dumr(:,l)=v3; dumt(3,ll)=l; dumgrad(:,ll)=b
+        elseif ( tete(2) .lt. 0.0_flyt .and. tete(3) .gt. 0.0_flyt ) then
+            ! annoying case
+            if ( abs(tete(3)-tete(1)) .gt. tolerance .and. &
+                 abs(tete(4)-tete(1)) .gt. tolerance .and. &
+                 abs(tete(4)-tete(2)) .gt. tolerance .and. &
+                 abs(tete(3)-tete(2)) .gt. tolerance ) then
+            
+            v1=cpts(:,1)-tete(1)/(e31)*(cpts(:,3)-cpts(:,1))
+            v2=cpts(:,1)-tete(1)/(e41)*(cpts(:,4)-cpts(:,1))
+            v3=cpts(:,2)-tete(2)/(e42)*(cpts(:,4)-cpts(:,2))
+            v4=cpts(:,2)-tete(2)/(e32)*(cpts(:,3)-cpts(:,2))
+            
+            ! Test building two triangles out of this, choose the pair
+            ! with as similar area as possible
+            f0=norm2( lo_cross(v2-v1,v4-v1) ) ! 124
+            f1=norm2( lo_cross(v4-v2,v3-v2) ) ! 324
+            !
+            f2=norm2( lo_cross(v3-v1,v2-v1) ) ! 132
+            f3=norm2( lo_cross(v2-v3,v4-v3) ) ! 134
+            !
+            if ( abs(f0-f1) .lt. abs(f3-f2) ) then
+                ! first case
+                ll=ll+1
+                l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v4; dumt(3,ll)=l; dumgrad(:,ll)=b
+!                dumind(ll)=i
+
+                ll=ll+1
+                l=l+1; dumr(:,l)=v2; dumt(1,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v3; dumt(2,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v4; dumt(3,ll)=l; dumgrad(:,ll)=b
+            else
+                ! second
+                ll=ll+1
+                l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v3; dumt(3,ll)=l; dumgrad(:,ll)=b
+                !
+                ll=ll+1
+                l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v3; dumt(2,ll)=l; dumgrad(:,ll)=b
+                l=l+1; dumr(:,l)=v4; dumt(3,ll)=l; dumgrad(:,ll)=b
+            endif
+            endif
+            !
+        elseif ( tete(3) .lt. 0.0_flyt .and. tete(4) .gt. 0.0_flyt ) then
+            ! easy again!
+            v1=cpts(:,4)-tete(4)/(tete(2)-tete(4))*(cpts(:,2)-cpts(:,4))
+            v2=cpts(:,4)-tete(4)/(tete(1)-tete(4))*(cpts(:,1)-cpts(:,4))
+            v3=cpts(:,4)-tete(4)/(tete(3)-tete(4))*(cpts(:,3)-cpts(:,4))
+            ! store
+            ll=ll+1
+            l=l+1; dumr(:,l)=v1; dumt(1,ll)=l; dumgrad(:,ll)=b
+            l=l+1; dumr(:,l)=v2; dumt(2,ll)=l; dumgrad(:,ll)=b
+            l=l+1; dumr(:,l)=v3; dumt(3,ll)=l; dumgrad(:,ll)=b
+        endif
+        !
+        if ( verb ) then
+            if ( mod(i,20) .eq. 0 ) then
+                call lo_progressbar(' ... building triangles',i,qp%ntet_tot)
+            endif
+        endif
+    enddo
+                
+    if ( verb ) call lo_progressbar(' ... building triangles',qp%ntet_tot,qp%ntet_tot)
+
+    ! Stop if I found no points    
+    if ( l .eq. 0 ) return
+
+    ! Add together gradients from triangles.
+    
+    
+    ! Remove the redundant points. Do this twice, with two different sets of verlet boxes.
+    call remove_redundant_points(dumr(:,1:l),dumt(:,1:ll),finr,fint,6)
+    if ( size(finr,2) .lt. 3 ) then
+        ! the reduction might remove all points
+        if ( allocated(finr) ) deallocate(finr)
+        if ( allocated(fint) ) deallocate(fint)
+        if ( allocated(fingrad) ) deallocate(fingrad)
+        return
+    endif
+    deallocate(dumr,dumt)
+    call remove_redundant_points(finr,fint,dumr,dumt,5)
+    deallocate(finr,fint)
+    if ( size(dumr,2) .lt. 3 ) then
+        ! the reduction might remove all points
+        return
+    endif
+    
+    ! Remove the too tiny triangles.
+    ntri=ll
+    allocate(ind(ntri))
+    ind=1
+    ! find triangles with zero area
+    do i=1,ntri
+        ! get the area of this triangle
+        v1=dumr(:,dumt(1,i))-dumr(:,dumt(3,i))
+        v2=dumr(:,dumt(2,i))-dumr(:,dumt(3,i))
+        if ( norm2(lo_cross(v1,v2)) .lt. lo_sqtol ) then
+            ind(i)=0
+        endif
+    enddo
+    
+    nfintri=sum(ind)
+    ! make space for the nice things
+    allocate(finr(3,size(dumr,2)))
+    allocate(fingrad(3,nfintri))
+    allocate(fint(3,nfintri))
+    fingrad=0.0_flyt
+    fint=0
+    finr=0.0_flyt
+    l=0
+    do i=1,ntri
+        if ( ind(i) .eq. 1 ) then
+            l=l+1
+            fint(:,l)=dumt(:,i)
+            fingrad(:,l)=dumgrad(:,i)
+        endif
+    enddo
+    finr=dumr
+
+    ! Fix the gradients
+    dumr=0.0_flyt
+    do i=1,nfintri
+        do j=1,3
+            k=fint(j,i)
+            dumr(:,k)=dumr(:,k)+fingrad(:,i)
+        enddo
+    enddo
+    lo_deallocate(fingrad)
+    lo_allocate(fingrad(3,size(dumr,2)))
+    fingrad=dumr
+
+    do i=1,size(fingrad,2)
+        fingrad(:,i)=fingrad(:,i)/norm2(fingrad(:,i))
+    enddo
+
+!    fixgrad: block
+!        integer :: n,nb
+!        type(lo_qpoint) :: qp1,qp2,qp3
+!        type(lo_phonon_dispersions_qpoint) :: drp1,drp2,drp3
+!        complex(flyt), dimension(:,:), allocatable :: D
+!        complex(flyt), dimension(:,:,:), allocatable :: Dq
+!        n=size(finr,2)
+!        allocate(fingrad(3,size(dumr,2)))
+!        fingrad=0.0_flyt
+!        !
+!        nb=fc%na*3
+!        lo_allocate(drp1%omega(nb))
+!        lo_allocate(drp1%egv(nb,nb))
+!        lo_allocate(drp1%vel(3,nb))
+!        lo_allocate(drp2%omega(nb))
+!        lo_allocate(drp2%egv(nb,nb))
+!        lo_allocate(drp2%vel(3,nb))
+!        lo_allocate(drp3%omega(nb))
+!        lo_allocate(drp3%egv(nb,nb))
+!        lo_allocate(drp3%vel(3,nb))
+!        lo_allocate(D(nb,nb))
+!        lo_allocate(Dq(3,nb,nb))
+!        lo_allocate(psisq(n))
+!        lo_allocate(tot_omega(n,3))
+!        lo_allocate(tot_egv(n,nb,3))
+!        lo_allocate(tot_q(n,3,3))
+!        !
+!        qp1%v=qpoint1%w
+!        qp1%w=qpoint1%w
+!        call lo_get_small_group_of_qpoint(qp1,uc)
+!        call drp1%generate(fc,uc,qp1)
+!        psisq=0.0_flyt
+!        tot_omega=0.0_flyt
+!        tot_egv=0.0_flyt
+!        tot_q=0.0_flyt
+!        !
+!        if ( verb ) call lo_progressbar_init()
+!        do i=1,n
+!            qp2%v=finr(:,i)
+!            qp2%w=finr(:,i)
+!            qp3%w=qp1%w+qp2%w
+!            qp3%w=qp3%w-uc%bz%gshift(qp3%w)
+!            qp3%v=qp3%w
+!            call lo_get_small_group_of_qpoint(qp2,uc)
+!            call lo_get_small_group_of_qpoint(qp3,uc)
+!            call drp2%generate(fc,uc,qp2)
+!            call drp3%generate(fc,uc,qp3)
+!            if ( plus ) then
+!                fingrad(:,i)=drp1%vel(:,b1)+drp2%vel(:,b2)-drp3%vel(:,b3)
+!            else
+!                fingrad(:,i)=drp1%vel(:,b1)-drp2%vel(:,b2)-drp3%vel(:,b3)
+!            endif
+!            ! Calculate intensities
+!            if ( calcintens ) then
+!                if ( verb ) then
+!                    if ( mod(i,20) .eq. 0 ) then
+!                        call lo_progressbar(' ... calculating intensities',i,n)
+!                    endif
+!                endif
+!                ! below is like thermal_conductivity/scatteringstrengths.f90
+!                ! (all this should be the same for plus and minus, right?)
+!                ! q-vectors with correct sign
+!                q1= qp1%w*lo_twopi !is this correct? (really not needed)
+!                q2=-qp2%w*lo_twopi
+!                q3=-qp3%w*lo_twopi
+!                ! frequencies, eigenvectors, q-vectors
+!                omega(1) = drp1%omega(b1)
+!                omega(2) = drp2%omega(b2)
+!                omega(3) = drp3%omega(b3)
+!                egv(:,1) = drp1%egv(:,b1)
+!                egv(:,2) = drp2%egv(:,b2)
+!                egv(:,3) = drp3%egv(:,b3)
+!                ! and the scattering amplitude
+!                c0=fct%scatteringamplitude(omega,egv,q2,q3)
+!                psisq(i) = abs(conjg(c0)*c0)
+!                ! put everything else together here so it's handy
+!                tot_omega(i,:) = omega;
+!                tot_egv(i,:,:) = egv;
+!                tot_q(i,:,1) = q1;
+!                tot_q(i,:,2) = q2;
+!                tot_q(i,:,3) = q3;
+!            endif
+!        enddo 
+!        if ( calcintens ) then
+!            call lo_progressbar(' ... calculating intensities',n,n)
+!        endif
+!    end block fixgrad
+    !
+end subroutine
+
+!> Pretty fast way of sorting four numbers. Stole it from stack overflow.
+pure function sort_four_numbers(n) result(ind)
+    !> the four numbers
+    real(flyt), dimension(4), intent(in) :: n
+    !> the output order so that n(ind) is sorted
+    integer, dimension(4) :: ind
+    !
+    integer :: low1,high1,low2,high2,highest,lowest,middle1,middle2
+    !
+    if ( n(1) <= n(2) ) then
+        low1 = 1
+        high1 = 2
+    else
+        low1 = 2
+        high1 = 1
+    endif
+
+    if ( n(3) <= n(4) ) then
+        low2 = 3
+        high2 = 4
+    else
+        low2 = 4
+        high2 = 3
+    endif
+
+    if ( n(low1) <= n(low2) ) then
+        lowest = low1
+        middle1 = low2
+    else
+        lowest = low2
+        middle1 = low1
+    endif
+
+    if ( n(high1) >= n(high2) ) then
+        highest = high1
+        middle2 = high2
+    else
+        highest = high2
+        middle2 = high1
+    endif
+
+    if ( n(middle1) < n(middle2) ) then
+        ind=(/lowest,middle1,middle2,highest/)
+    else
+        ind=(/lowest,middle2,middle1,highest/)
+    endif
+    !
+end function
+
+!> use Verlet boxes to remove redundant points
+subroutine remove_redundant_points(r,tri,ur,utri,nb)
+    !> original points
+    real(flyt), dimension(:,:), intent(in) :: r
+    !> original triangles
+    integer, dimension(:,:), intent(in) :: tri
+    !> the unique points
+    real(flyt), dimension(:,:), allocatable, intent(out) :: ur
+    !> the new, fancy triangles
+    integer, dimension(:,:), allocatable, intent(out) :: utri
+    !> number of boxes to use
+    integer, intent(in) :: nb
+    !
+    type(lo_points_in_boxes), dimension(:,:,:), allocatable :: b
+    integer(flyt), dimension(:), allocatable :: dumi,dumj,dumk
+    integer, dimension(3) :: gi
+    integer :: i,j,k,l
+    integer :: np,ntri
+    !
+    real(flyt), dimension(:,:), allocatable :: dum
+    real(flyt), dimension(3) :: minv,maxv,v1,v2
+    real(flyt) :: t0,t1
+    
+    ! Get the boundaries of the box
+    t0=walltime()
+    np=size(r,2)
+    ntri=size(tri,2)
+    
+    ! Get the box dimensions
+    minv=lo_huge
+    maxv=-lo_huge
+    do i=1,np
+        do j=1,3
+            minv(j)=min(r(j,i),minv(j))
+            maxv(j)=max(r(j,i),maxv(j))
+        enddo
+    enddo
+
+    ! It could be just a single point or something like that
+    if ( lo_sqnorm(minv-maxv) .lt. lo_sqtol ) then
+        lo_allocate(ur(3,1))
+        lo_allocate(utri(3,1))
+        ur=0.0_flyt
+        utri=0
+        return
+    endif
+    ! pad it a little
+    minv=minv-abs(maxv-minv)*0.001_flyt
+    maxv=maxv+abs(maxv-minv)*0.001_flyt
+    
+    ! Sort these into boxes, first reset the counter
+    allocate(b(nb,nb,nb))
+    do i=1,nb
+    do j=1,nb
+    do k=1,nb
+        b(i,j,k)%n=0
+    enddo
+    enddo
+    enddo
+    ! Count particles per box
+    do i=1,np
+        gi=box_from_coordinates(r(:,i),minv,maxv,nb)
+        b(gi(1),gi(2),gi(3))%n=b(gi(1),gi(2),gi(3))%n+1
+    enddo
+    ! Make some space
+    l=0
+    do i=1,nb
+    do j=1,nb
+    do k=1,nb
+        if ( b(i,j,k)%n .gt. 0 ) then
+            l=l+b(i,j,k)%n
+            lo_allocate(b(i,j,k)%ind( b(i,j,k)%n ))
+        endif
+    enddo
+    enddo
+    enddo
+    ! Stuff the boxes
+    do i=1,nb
+    do j=1,nb
+    do k=1,nb
+        b(i,j,k)%n=0
+    enddo
+    enddo
+    enddo
+    do i=1,np
+        gi=box_from_coordinates(r(:,i),minv,maxv,nb)
+        b(gi(1),gi(2),gi(3))%n=b(gi(1),gi(2),gi(3))%n+1
+        b(gi(1),gi(2),gi(3))%ind( b(gi(1),gi(2),gi(3))%n )=i
+    enddo
+    
+    ! Find the unique
+    lo_allocate(dumi(np))
+    lo_allocate(dumj(np))
+    lo_allocate(dumk(np))
+    lo_allocate(dum(3,np))
+    !
+    dumi=0
+    dumj=1
+    l=0
+    do i=1,np
+        ! Which box is it in?
+        gi=box_from_coordinates(r(:,i),minv,maxv,nb)
+        ! Compare with points in the same box
+        l=0
+        do j=1,b(gi(1),gi(2),gi(3))%n
+            k=b(gi(1),gi(2),gi(3))%ind(j)
+            if ( k .gt. i ) then
+                if ( lo_sqnorm(r(:,i)-r(:,k)) .lt. lo_sqtol ) then
+                    l=l+1
+                    dumj(k)=0
+                    dumi(k)=i
+                endif
+            endif
+        enddo
+        !
+    enddo
+    
+    ! Figure out the mapping
+    l=sum(dumj)
+    lo_allocate(ur(3,l))
+    j=0
+    dumk=0
+    do i=1,np
+        if ( dumj(i) .eq. 1 ) then
+            j=j+1
+            ur(:,j)=r(:,i)
+            dumk(i)=j
+        endif
+    enddo
+    
+    ! And the mapping for the redundant points
+    do i=1,np
+        if ( dumk(i) .eq. 0 ) then
+            j=i
+            do
+                j=dumi(j)
+                k=dumk(j)
+                if ( k .ne. 0 ) exit
+            enddo
+            dumk(i)=k
+        endif
+    enddo
+    
+    ! and the triangles
+    lo_allocate(utri(3,ntri))
+    do i=1,ntri
+        do j=1,3
+            utri(j,i)=dumk( tri(j,i) )
+        enddo
+    enddo
+    
+    ! and some cleanup
+    lo_deallocate(dum)
+    lo_deallocate(dumi)
+    lo_deallocate(dumj)
+    do i=1,nb
+    do j=1,nb
+    do k=1,nb
+        if ( b(i,j,k)%n .gt. 0 ) then
+            lo_deallocate(b(i,j,k)%ind)
+        endif
+    enddo
+    enddo
+    enddo
+    lo_deallocate(b)
+    contains
+
+    function box_from_coordinates(r,minv,maxv,nb) result(gi)
+        real(flyt), dimension(3), intent(in) :: r,minv,maxv
+        integer, intent(in) :: nb
+        integer, dimension(3) :: gi
+        !
+        integer :: i
+        !
+        do i=1,3
+            gi(i)=floor(nb*(r(i)-minv(i))/(maxv(i)-minv(i)))+1
+        enddo
+    end function
+
+end subroutine
+

--- a/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
+++ b/src/phasespace_surface/type_phasespacesurface_cleanmesh.f90
@@ -73,9 +73,9 @@ subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1
     endif
     ! Fetch the tetrahedron energies
     ! space for possible points
-    lo_allocate(dumr(3,qp%ntet_tot*4))
-    lo_allocate(dumt(3,qp%ntet_tot*4))
-    lo_allocate(dumgrad(3,qp%ntet_tot*4))
+    lo_allocate(dumr(3,qp%n_full_tet*4))
+    lo_allocate(dumt(3,qp%n_full_tet*4))
+    lo_allocate(dumgrad(3,qp%n_full_tet*4))
     dumr=0.0_flyt
     dumt=0
     dumgrad=0.0_flyt
@@ -84,11 +84,11 @@ subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1
     l=0
     ll=0
     if ( verb ) call lo_progressbar_init()
-    do i=1,qp%ntet_tot
+    do i=1,qp%n_full_tet
         ! fetch energy at the corners, and coordinates
         do j=1,4            
-            ii=qp%atet(i)%gridind(j)
-            cpts(:,j)=qp%ap(ii)%w
+            ii=qp%at(i)%full_index(j)
+            cpts(:,j)=qp%ap(ii)%r
             tete(j)=fvals(ii)-isoval
         enddo
         sorti=sort_four_numbers(tete)
@@ -196,12 +196,12 @@ subroutine bz_isosurface(qp,fvals,isoval,finr,fint,fingrad,uc,fc,qpoint1,plus,b1
         !
         if ( verb ) then
             if ( mod(i,20) .eq. 0 ) then
-                call lo_progressbar(' ... building triangles',i,qp%ntet_tot)
+                call lo_progressbar(' ... building triangles',i,qp%n_full_tet)
             endif
         endif
     enddo
                 
-    if ( verb ) call lo_progressbar(' ... building triangles',qp%ntet_tot,qp%ntet_tot)
+    if ( verb ) call lo_progressbar(' ... building triangles',qp%n_full_tet,qp%n_full_tet)
 
     ! Stop if I found no points    
     if ( l .eq. 0 ) return

--- a/src/phasespace_surface/type_phasespacesurface_energycalculations.f90
+++ b/src/phasespace_surface/type_phasespacesurface_energycalculations.f90
@@ -1,5 +1,5 @@
 
-subroutine energy_values_on_vertices(qp1,qp,uc,fc,energy_plus,energy_minus)
+subroutine energy_values_on_vertices(qp1,qp,uc,fc,energy_plus,energy_minus,mem)
     !> the q-point in question
     type(lo_qpoint), intent(in) :: qp1 
     !> qpoint mesh
@@ -10,6 +10,8 @@ subroutine energy_values_on_vertices(qp1,qp,uc,fc,energy_plus,energy_minus)
     type(lo_forceconstant_secondorder), intent(inout) :: fc
     !> energy values
     real(flyt), dimension(:,:,:,:), intent(out) :: energy_plus,energy_minus
+    !> memory helper
+    type(lo_mem_helper), intent(inout) :: mem
     !
     type(lo_qpoint) :: qp2,qp3
     type(lo_phonon_dispersions_qpoint) :: drp1,drp2,drp3
@@ -19,14 +21,14 @@ subroutine energy_values_on_vertices(qp1,qp,uc,fc,energy_plus,energy_minus)
     energy_plus=0.0_flyt
     energy_minus=0.0_flyt
     ! get the starting point
-    call drp1%generate(fc,uc,qp1)
-    do i=1,qp%nq_tot
-        qp2%w=qp%ap(i)%w
-        qp2%noperations=0
-        qp3%w=qp2%w+qp1%w
-        qp3%noperations=0
-        call drp2%generate(fc,uc,qp2)
-        call drp3%generate(fc,uc,qp3)
+    call drp1%generate(fc,uc,mem,qp1)
+    do i=1,qp%n_full_point
+        qp2%r=qp%ap(i)%r
+        qp2%n_invariant_operation=0
+        qp3%r=qp2%r+qp1%r
+        qp3%n_invariant_operation=0
+        call drp2%generate(fc,uc,mem,qp2)
+        call drp3%generate(fc,uc,mem,qp3)
         do b1=1,nb
         do b2=1,nb
         do b3=1,nb

--- a/src/phasespace_surface/type_phasespacesurface_energycalculations.f90
+++ b/src/phasespace_surface/type_phasespacesurface_energycalculations.f90
@@ -1,7 +1,7 @@
 
-subroutine energy_values_on_vertices(qp1,qp,uc,fc,energy_plus,energy_minus,mem)
+subroutine energy_values_on_vertices(qp1, qp, uc, fc, energy_plus, energy_minus, mem)
     !> the q-point in question
-    type(lo_qpoint), intent(in) :: qp1 
+    type(lo_qpoint), intent(in) :: qp1
     !> qpoint mesh
     class(lo_qpoint_mesh), intent(in) :: qp
     !> unitcell
@@ -9,35 +9,34 @@ subroutine energy_values_on_vertices(qp1,qp,uc,fc,energy_plus,energy_minus,mem)
     !> forceconstant
     type(lo_forceconstant_secondorder), intent(inout) :: fc
     !> energy values
-    real(flyt), dimension(:,:,:,:), intent(out) :: energy_plus,energy_minus
+    real(flyt), dimension(:, :, :, :), intent(out) :: energy_plus, energy_minus
     !> memory helper
     type(lo_mem_helper), intent(inout) :: mem
     !
-    type(lo_qpoint) :: qp2,qp3
-    type(lo_phonon_dispersions_qpoint) :: drp1,drp2,drp3
-    integer :: i,nb,b1,b2,b3
+    type(lo_qpoint) :: qp2, qp3
+    type(lo_phonon_dispersions_qpoint) :: drp1, drp2, drp3
+    integer :: i, nb, b1, b2, b3
     !
-    nb=fc%na*3
-    energy_plus=0.0_flyt
-    energy_minus=0.0_flyt
+    nb = fc%na*3
+    energy_plus = 0.0_flyt
+    energy_minus = 0.0_flyt
     ! get the starting point
-    call drp1%generate(fc,uc,mem,qp1)
-    do i=1,qp%n_full_point
-        qp2%r=qp%ap(i)%r
-        qp2%n_invariant_operation=0
-        qp3%r=qp2%r+qp1%r
-        qp3%n_invariant_operation=0
-        call drp2%generate(fc,uc,mem,qp2)
-        call drp3%generate(fc,uc,mem,qp3)
-        do b1=1,nb
-        do b2=1,nb
-        do b3=1,nb
-            energy_plus(i,b1,b2,b3)=drp1%omega(b1)+drp2%omega(b2)-drp3%omega(b3)
-            energy_minus(i,b1,b2,b3)=drp1%omega(b1)-drp2%omega(b2)-drp3%omega(b3)
-        enddo
-        enddo
-        enddo
-    enddo
+    call drp1%generate(fc, uc, mem, qp1)
+    do i = 1, qp%n_full_point
+        qp2%r = qp%ap(i)%r
+        qp2%n_invariant_operation = 0
+        qp3%r = qp2%r + qp1%r
+        qp3%n_invariant_operation = 0
+        call drp2%generate(fc, uc, mem, qp2)
+        call drp3%generate(fc, uc, mem, qp3)
+        do b1 = 1, nb
+        do b2 = 1, nb
+        do b3 = 1, nb
+            energy_plus(i, b1, b2, b3) = drp1%omega(b1) + drp2%omega(b2) - drp3%omega(b3)
+            energy_minus(i, b1, b2, b3) = drp1%omega(b1) - drp2%omega(b2) - drp3%omega(b3)
+        end do
+        end do
+        end do
+    end do
 end subroutine
-
 

--- a/src/phasespace_surface/type_phasespacesurface_energycalculations.f90
+++ b/src/phasespace_surface/type_phasespacesurface_energycalculations.f90
@@ -1,0 +1,41 @@
+
+subroutine energy_values_on_vertices(qp1,qp,uc,fc,energy_plus,energy_minus)
+    !> the q-point in question
+    type(lo_qpoint), intent(in) :: qp1 
+    !> qpoint mesh
+    class(lo_qpoint_mesh), intent(in) :: qp
+    !> unitcell
+    type(lo_crystalstructure), intent(in) :: uc
+    !> forceconstant
+    type(lo_forceconstant_secondorder), intent(inout) :: fc
+    !> energy values
+    real(flyt), dimension(:,:,:,:), intent(out) :: energy_plus,energy_minus
+    !
+    type(lo_qpoint) :: qp2,qp3
+    type(lo_phonon_dispersions_qpoint) :: drp1,drp2,drp3
+    integer :: i,nb,b1,b2,b3
+    !
+    nb=fc%na*3
+    energy_plus=0.0_flyt
+    energy_minus=0.0_flyt
+    ! get the starting point
+    call drp1%generate(fc,uc,qp1)
+    do i=1,qp%nq_tot
+        qp2%w=qp%ap(i)%w
+        qp2%noperations=0
+        qp3%w=qp2%w+qp1%w
+        qp3%noperations=0
+        call drp2%generate(fc,uc,qp2)
+        call drp3%generate(fc,uc,qp3)
+        do b1=1,nb
+        do b2=1,nb
+        do b3=1,nb
+            energy_plus(i,b1,b2,b3)=drp1%omega(b1)+drp2%omega(b2)-drp3%omega(b3)
+            energy_minus(i,b1,b2,b3)=drp1%omega(b1)-drp2%omega(b2)-drp3%omega(b3)
+        enddo
+        enddo
+        enddo
+    enddo
+end subroutine
+
+

--- a/src/phasespace_surface/type_phasespacesurface_povray.f90
+++ b/src/phasespace_surface/type_phasespacesurface_povray.f90
@@ -1,6 +1,6 @@
 
 !> write as a POV-Ray scene
-subroutine write_to_povray(ps,uc,filename,theta,phi,modes_plusminus_clr_alpha,quality)
+subroutine write_to_povray(ps, uc, filename, theta, phi, modes_plusminus_clr_alpha, quality)
     !> surface
     class(lo_phasespacesurface), intent(in) :: ps
     !> unitcell
@@ -12,78 +12,78 @@ subroutine write_to_povray(ps,uc,filename,theta,phi,modes_plusminus_clr_alpha,qu
     !> phi angle
     real(flyt), intent(in) :: phi
     !> which surfaces to look at, how to color them, alpha channel
-    integer, dimension(:,:), intent(in) :: modes_plusminus_clr_alpha
+    integer, dimension(:, :), intent(in) :: modes_plusminus_clr_alpha
     !> how nice to render
     integer, intent(in) :: quality
 
-    integer :: i,j,k,l,u,ii,jj,kk,ntri,npts,nsurf,srf
-    integer :: b1,b2,b3
-    real(flyt) :: f0,cylwidth
-    real(flyt), dimension(3) :: v0,v1,v2,g0,g1,g2
-    real(flyt), dimension(3) :: v_cam,v_up,v_light1,v_light2
-    real(flyt), dimension(:,:), allocatable :: grad
+    integer :: i, j, k, l, u, ii, jj, kk, ntri, npts, nsurf, srf
+    integer :: b1, b2, b3
+    real(flyt) :: f0, cylwidth
+    real(flyt), dimension(3) :: v0, v1, v2, g0, g1, g2
+    real(flyt), dimension(3) :: v_cam, v_up, v_light1, v_light2
+    real(flyt), dimension(:, :), allocatable :: grad
     logical :: plus
 
-    write(*,*) ''
-    write(*,*) 'Writing surfaces to POV-Ray'
+    write (*, *) ''
+    write (*, *) 'Writing surfaces to POV-Ray'
 
     ! Set the rendering options
-    u=open_file('out',trim(filename)//'.ini')
-        write(u,*) 'Input_File_Name='//trim(filename)//'.pov'
-        write(u,*) 'Quality = ',tochar(quality)
-        write(u,*) 'Antialias = 1'
-        write(u,*) 'Antialias_Depth = 6'
-        write(u,*) 'Height = 1080'
-        write(u,*) 'Width = 1920'
-    close(u)
+    u = open_file('out', trim(filename)//'.ini')
+    write (u, *) 'Input_File_Name='//trim(filename)//'.pov'
+    write (u, *) 'Quality = ', tochar(quality)
+    write (u, *) 'Antialias = 1'
+    write (u, *) 'Antialias_Depth = 6'
+    write (u, *) 'Height = 1080'
+    write (u, *) 'Width = 1920'
+    close (u)
 
-    u=open_file('out',trim(filename)//'.pov')
-        ! First I write the povray header, setting up the scene.
-        ! set some colors
-        write(u,*) '#include "colors.inc"'
-        write(u,*) '#declare BZCOLOR = rgbt<0.6,0.6,0.6,0.98>;'
-        write(u,*) 'background { color White }'
-        ! figure out where to put the camera
-        v0(1)=sin(theta*lo_pi/180.0_flyt)*cos(phi*lo_pi/180.0_flyt)
-        v0(2)=sin(theta*lo_pi/180.0_flyt)
-        v0(3)=cos(theta*lo_pi/180.0_flyt)
-        ! scale the location of the camera such at the distance from origin is 2.5 times the radius of the
-        ! bounding sphere of the BZ, seems like a robust choice.
-        v0=v0*uc%bz%rmax/norm2(v0)
-        v_cam=v0*2.5
-        write(u,*) 'camera {'
-        write(u,*) '  location <',tochar(v_cam(1)),',',tochar(v_cam(2)),',',tochar(v_cam(3)),'>'
-        write(u,*) '  up <0,0.9,0>'
-        write(u,*) '  right <1.6,0,0>  // right,up -> 16:9'
-        write(u,*) '  look_at <0, 0, 0>'
-        write(u,*) '}'
-        v_up=[0,0,1]*1.0_flyt
-        v0=lo_cross(v_up,v_cam)
-        v0=v0/norm2(v0)+0.5_flyt*v_cam/norm2(v0)+v_up
-        v_light1=v0
-        v_light1=v_light1*10.0_flyt/norm2(v_light1)
-        ! Set the light source
-        write(u,*) 'light_source {'
-        write(u,*) '  <',tochar(v_light1(1)),',',tochar(v_light1(2)),',',tochar(v_light1(3)),'>'
-        write(u,*) '  color White'
-        write(u,*) '  area_light <.5, 0, 0>, <0, 0, .5>, 5, 5'
-        write(u,*) '  adaptive 1'
-        write(u,*) '  jitter'
-        write(u,*) '}'
-        write(u,*) 'light_source {'
-        write(u,*) '  <10, 20, 10>'
-        write(u,*) '  color Blue'
-        write(u,*) '  area_light <5, 0, 0>, <0, 0, 5>, 5, 5'
-        write(u,*) '  adaptive 1'
-        write(u,*) '  jitter'
-        write(u,*) '}'
-        write(u,*) ''
+    u = open_file('out', trim(filename)//'.pov')
+    ! First I write the povray header, setting up the scene.
+    ! set some colors
+    write (u, *) '#include "colors.inc"'
+    write (u, *) '#declare BZCOLOR = rgbt<0.6,0.6,0.6,0.98>;'
+    write (u, *) 'background { color White }'
+    ! figure out where to put the camera
+    v0(1) = sin(theta*lo_pi/180.0_flyt)*cos(phi*lo_pi/180.0_flyt)
+    v0(2) = sin(theta*lo_pi/180.0_flyt)
+    v0(3) = cos(theta*lo_pi/180.0_flyt)
+    ! scale the location of the camera such at the distance from origin is 2.5 times the radius of the
+    ! bounding sphere of the BZ, seems like a robust choice.
+    v0 = v0*uc%bz%rmax/norm2(v0)
+    v_cam = v0*2.5
+    write (u, *) 'camera {'
+    write (u, *) '  location <', tochar(v_cam(1)), ',', tochar(v_cam(2)), ',', tochar(v_cam(3)), '>'
+    write (u, *) '  up <0,0.9,0>'
+    write (u, *) '  right <1.6,0,0>  // right,up -> 16:9'
+    write (u, *) '  look_at <0, 0, 0>'
+    write (u, *) '}'
+    v_up = [0, 0, 1]*1.0_flyt
+    v0 = lo_cross(v_up, v_cam)
+    v0 = v0/norm2(v0) + 0.5_flyt*v_cam/norm2(v0) + v_up
+    v_light1 = v0
+    v_light1 = v_light1*10.0_flyt/norm2(v_light1)
+    ! Set the light source
+    write (u, *) 'light_source {'
+    write (u, *) '  <', tochar(v_light1(1)), ',', tochar(v_light1(2)), ',', tochar(v_light1(3)), '>'
+    write (u, *) '  color White'
+    write (u, *) '  area_light <.5, 0, 0>, <0, 0, .5>, 5, 5'
+    write (u, *) '  adaptive 1'
+    write (u, *) '  jitter'
+    write (u, *) '}'
+    write (u, *) 'light_source {'
+    write (u, *) '  <10, 20, 10>'
+    write (u, *) '  color Blue'
+    write (u, *) '  area_light <5, 0, 0>, <0, 0, 5>, 5, 5'
+    write (u, *) '  adaptive 1'
+    write (u, *) '  jitter'
+    write (u, *) '}'
+    write (u, *) ''
 
-        ! Now the header is done, with cameras and lights. Next up is defining the BZ, which
-        ! I do as both a polyhedron that is very transparent. Then I put tiny cylinders along the
-        ! edges. These cylinder reflect no light, and cast no shadow, so it looksjust like black lines.
+    ! Now the header is done, with cameras and lights. Next up is defining the BZ, which
+    ! I do as both a polyhedron that is very transparent. Then I put tiny cylinders along the
+    ! edges. These cylinder reflect no light, and cast no shadow, so it looksjust like black lines.
 
-        ! define the BZ
+    ! define the BZ
 !        do i=1,uc%bz%nfaces
 !            write(u,*) 'polygon {'
 !            j=uc%bz%face(i)%n+1
@@ -96,116 +96,116 @@ subroutine write_to_povray(ps,uc,filename,theta,phi,modes_plusminus_clr_alpha,qu
 !            write(u,*) '    texture { pigment { color BZCOLOR }}'
 !            write(u,*) '}'
 !        enddo
-        ! draw some cylinders along the edges
-        cylwidth=uc%bz%rmax/500.0_flyt
-        do i=1,uc%bz%nedges
-            write(u,*) 'cylinder {'
-            v0=uc%bz%r(:,uc%bz%edge(i)%i1)
-            v1=uc%bz%r(:,uc%bz%edge(i)%i2)
-            write(u,"(4X,'<',F11.6,',',F11.6,',',F11.6,'>,<',F11.6,',',F11.6,',',F11.6,'>,',F11.6)") v0,v1,cylwidth
-            write(u,*) '    texture { pigment { color Black } }'  
-            write(u,*) '    no_shadow' 
-            write(u,*) '}'
-        enddo
+    ! draw some cylinders along the edges
+    cylwidth = uc%bz%rmax/500.0_flyt
+    do i = 1, uc%bz%nedges
+        write (u, *) 'cylinder {'
+        v0 = uc%bz%r(:, uc%bz%edge(i)%i1)
+        v1 = uc%bz%r(:, uc%bz%edge(i)%i2)
+        write (u, "(4X,'<',F11.6,',',F11.6,',',F11.6,'>,<',F11.6,',',F11.6,',',F11.6,'>,',F11.6)") v0, v1, cylwidth
+        write (u, *) '    texture { pigment { color Black } }'
+        write (u, *) '    no_shadow'
+        write (u, *) '}'
+    end do
 
-        ! Now the idea is to dump triangles defining the phasespace surface. There are nb^3*2 phasespace surfaces for
-        ! each q, so we have to define which one to look for. That's done in the input with 6 integers per surface.
-        nsurf=size(modes_plusminus_clr_alpha,2)
-        do srf=1,nsurf
-            ! get the specification for this surface
-            if ( modes_plusminus_clr_alpha(4,srf) .eq. 0 ) then 
-                plus=.true.
-            else
-                plus=.false.
-            endif
-            b1=modes_plusminus_clr_alpha(1,srf)
-            b2=modes_plusminus_clr_alpha(2,srf)
-            b3=modes_plusminus_clr_alpha(3,srf)
-            ! define the color
-            i=modes_plusminus_clr_alpha(5,srf)
-            f0=( 100-modes_plusminus_clr_alpha(6,srf) )/100.0_flyt
-            select case(i)
-            case(1)
-                write(u,*) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.8,0.1,0.1,0,'//tochar(f0)//'>;'
-            case(2)
-                write(u,*) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.1,0.8,0.1,0,'//tochar(f0)//'>;'
-            case(3)
-                write(u,*) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.3,0.3,0.9,0,'//tochar(f0)//'>;'
-            end select
+    ! Now the idea is to dump triangles defining the phasespace surface. There are nb^3*2 phasespace surfaces for
+    ! each q, so we have to define which one to look for. That's done in the input with 6 integers per surface.
+    nsurf = size(modes_plusminus_clr_alpha, 2)
+    do srf = 1, nsurf
+        ! get the specification for this surface
+        if (modes_plusminus_clr_alpha(4, srf) .eq. 0) then
+            plus = .true.
+        else
+            plus = .false.
+        end if
+        b1 = modes_plusminus_clr_alpha(1, srf)
+        b2 = modes_plusminus_clr_alpha(2, srf)
+        b3 = modes_plusminus_clr_alpha(3, srf)
+        ! define the color
+        i = modes_plusminus_clr_alpha(5, srf)
+        f0 = (100 - modes_plusminus_clr_alpha(6, srf))/100.0_flyt
+        select case (i)
+        case (1)
+            write (u, *) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.8,0.1,0.1,0,'//tochar(f0)//'>;'
+        case (2)
+            write (u, *) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.1,0.8,0.1,0,'//tochar(f0)//'>;'
+        case (3)
+            write (u, *) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.3,0.3,0.9,0,'//tochar(f0)//'>;'
+        end select
 
-            ! Dump the triangles that make up the surface
-            if ( plus ) then
-                ntri=ps%plus(b1,b2,b3)%ntri
-                npts=ps%plus(b1,b2,b3)%npts
-                if ( ntri .gt. 0 ) then
-                    ! print the mesh
-                    write(u,*) 'mesh {'
-                    do i=1,ntri
-                        ii=ps%plus(b1,b2,b3)%tri(1,i)
-                        jj=ps%plus(b1,b2,b3)%tri(2,i)
-                        kk=ps%plus(b1,b2,b3)%tri(3,i)
-                        v0=ps%plus(b1,b2,b3)%pts(:,ii) 
-                        v1=ps%plus(b1,b2,b3)%pts(:,jj) 
-                        v2=ps%plus(b1,b2,b3)%pts(:,kk)
-                        g0=ps%plus(b1,b2,b3)%grad(:,ii) 
-                        g1=ps%plus(b1,b2,b3)%grad(:,jj) 
-                        g2=ps%plus(b1,b2,b3)%grad(:,kk)
-                        !write(u,"(1X,A)",advance='no') 'triangle { '
-                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
-                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v1
-                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v2
-                        !write(u,*) '}'
-                        write(u,"(1X,A)",advance='no') 'smooth_triangle { '
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g0
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v1
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g1
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v2
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') g2
-                        write(u,*) '}'
-                    enddo
-                    write(u,*) '    texture { pigment { color SFCOLOR'//tochar(srf)//' }}'
-                    write(u,*) '    finish { ambient .4 diffuse .6 phong .2 }'
-                    write(u,*) '}'
-                endif
-            else
-                ntri=ps%minus(b1,b2,b3)%ntri
-                npts=ps%minus(b1,b2,b3)%npts
-                if ( ntri .gt. 0 ) then
-                    ! print the mesh
-                    write(u,*) 'mesh {'
-                    do i=1,ntri
-                        ii=ps%minus(b1,b2,b3)%tri(1,i)
-                        jj=ps%minus(b1,b2,b3)%tri(2,i)
-                        kk=ps%minus(b1,b2,b3)%tri(3,i)
-                        v0=ps%minus(b1,b2,b3)%pts(:,ii) 
-                        v1=ps%minus(b1,b2,b3)%pts(:,jj) 
-                        v2=ps%minus(b1,b2,b3)%pts(:,kk)
-                        g0=ps%minus(b1,b2,b3)%grad(:,ii) 
-                        g1=ps%minus(b1,b2,b3)%grad(:,jj) 
-                        g2=ps%minus(b1,b2,b3)%grad(:,kk)
-                        !write(u,"(1X,A)",advance='no') 'triangle { '
-                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
-                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v1
-                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v2
-                        !write(u,*) '}'
-                        write(u,"(1X,A)",advance='no') 'smooth_triangle { '
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g0
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v1
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g1
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v2
-                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') g2
-                        write(u,*) '}'
-                    enddo
-                    write(u,*) '    texture { pigment { color SFCOLOR'//tochar(srf)//' }}'
-                    write(u,*) '    finish { ambient .4 diffuse .6 phong .2 }'
-                    write(u,*) '}'
-                endif
-            endif
-            !
-        enddo
+        ! Dump the triangles that make up the surface
+        if (plus) then
+            ntri = ps%plus(b1, b2, b3)%ntri
+            npts = ps%plus(b1, b2, b3)%npts
+            if (ntri .gt. 0) then
+                ! print the mesh
+                write (u, *) 'mesh {'
+                do i = 1, ntri
+                    ii = ps%plus(b1, b2, b3)%tri(1, i)
+                    jj = ps%plus(b1, b2, b3)%tri(2, i)
+                    kk = ps%plus(b1, b2, b3)%tri(3, i)
+                    v0 = ps%plus(b1, b2, b3)%pts(:, ii)
+                    v1 = ps%plus(b1, b2, b3)%pts(:, jj)
+                    v2 = ps%plus(b1, b2, b3)%pts(:, kk)
+                    g0 = ps%plus(b1, b2, b3)%grad(:, ii)
+                    g1 = ps%plus(b1, b2, b3)%grad(:, jj)
+                    g2 = ps%plus(b1, b2, b3)%grad(:, kk)
+                    !write(u,"(1X,A)",advance='no') 'triangle { '
+                    !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
+                    !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v1
+                    !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v2
+                    !write(u,*) '}'
+                    write (u, "(1X,A)", advance='no') 'smooth_triangle { '
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') v0
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') g0
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>')", advance='no') v1
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') g1
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') v2
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>')", advance='no') g2
+                    write (u, *) '}'
+                end do
+                write (u, *) '    texture { pigment { color SFCOLOR'//tochar(srf)//' }}'
+                write (u, *) '    finish { ambient .4 diffuse .6 phong .2 }'
+                write (u, *) '}'
+            end if
+        else
+            ntri = ps%minus(b1, b2, b3)%ntri
+            npts = ps%minus(b1, b2, b3)%npts
+            if (ntri .gt. 0) then
+                ! print the mesh
+                write (u, *) 'mesh {'
+                do i = 1, ntri
+                    ii = ps%minus(b1, b2, b3)%tri(1, i)
+                    jj = ps%minus(b1, b2, b3)%tri(2, i)
+                    kk = ps%minus(b1, b2, b3)%tri(3, i)
+                    v0 = ps%minus(b1, b2, b3)%pts(:, ii)
+                    v1 = ps%minus(b1, b2, b3)%pts(:, jj)
+                    v2 = ps%minus(b1, b2, b3)%pts(:, kk)
+                    g0 = ps%minus(b1, b2, b3)%grad(:, ii)
+                    g1 = ps%minus(b1, b2, b3)%grad(:, jj)
+                    g2 = ps%minus(b1, b2, b3)%grad(:, kk)
+                    !write(u,"(1X,A)",advance='no') 'triangle { '
+                    !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
+                    !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v1
+                    !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v2
+                    !write(u,*) '}'
+                    write (u, "(1X,A)", advance='no') 'smooth_triangle { '
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') v0
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') g0
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>')", advance='no') v1
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') g1
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>,')", advance='no') v2
+                    write (u, "('<',F11.6,',',F11.6,',',F11.6,'>')", advance='no') g2
+                    write (u, *) '}'
+                end do
+                write (u, *) '    texture { pigment { color SFCOLOR'//tochar(srf)//' }}'
+                write (u, *) '    finish { ambient .4 diffuse .6 phong .2 }'
+                write (u, *) '}'
+            end if
+        end if
+        !
+    end do
 
-    close(u)
+    close (u)
 
 end subroutine

--- a/src/phasespace_surface/type_phasespacesurface_povray.f90
+++ b/src/phasespace_surface/type_phasespacesurface_povray.f90
@@ -1,0 +1,211 @@
+
+!> write as a POV-Ray scene
+subroutine write_to_povray(ps,uc,filename,theta,phi,modes_plusminus_clr_alpha,quality)
+    !> surface
+    class(lo_phasespacesurface), intent(in) :: ps
+    !> unitcell
+    type(lo_crystalstructure), intent(in) :: uc
+    !> filename
+    character(len=*), intent(in) :: filename
+    !> theta angle
+    real(flyt), intent(in) :: theta
+    !> phi angle
+    real(flyt), intent(in) :: phi
+    !> which surfaces to look at, how to color them, alpha channel
+    integer, dimension(:,:), intent(in) :: modes_plusminus_clr_alpha
+    !> how nice to render
+    integer, intent(in) :: quality
+
+    integer :: i,j,k,l,u,ii,jj,kk,ntri,npts,nsurf,srf
+    integer :: b1,b2,b3
+    real(flyt) :: f0,cylwidth
+    real(flyt), dimension(3) :: v0,v1,v2,g0,g1,g2
+    real(flyt), dimension(3) :: v_cam,v_up,v_light1,v_light2
+    real(flyt), dimension(:,:), allocatable :: grad
+    logical :: plus
+
+    write(*,*) ''
+    write(*,*) 'Writing surfaces to POV-Ray'
+
+    ! Set the rendering options
+    u=open_file('out',trim(filename)//'.ini')
+        write(u,*) 'Input_File_Name='//trim(filename)//'.pov'
+        write(u,*) 'Quality = ',tochar(quality)
+        write(u,*) 'Antialias = 1'
+        write(u,*) 'Antialias_Depth = 6'
+        write(u,*) 'Height = 1080'
+        write(u,*) 'Width = 1920'
+    close(u)
+
+    u=open_file('out',trim(filename)//'.pov')
+        ! First I write the povray header, setting up the scene.
+        ! set some colors
+        write(u,*) '#include "colors.inc"'
+        write(u,*) '#declare BZCOLOR = rgbt<0.6,0.6,0.6,0.98>;'
+        write(u,*) 'background { color White }'
+        ! figure out where to put the camera
+        v0(1)=sin(theta*lo_pi/180.0_flyt)*cos(phi*lo_pi/180.0_flyt)
+        v0(2)=sin(theta*lo_pi/180.0_flyt)
+        v0(3)=cos(theta*lo_pi/180.0_flyt)
+        ! scale the location of the camera such at the distance from origin is 2.5 times the radius of the
+        ! bounding sphere of the BZ, seems like a robust choice.
+        v0=v0*uc%bz%rmax/norm2(v0)
+        v_cam=v0*2.5
+        write(u,*) 'camera {'
+        write(u,*) '  location <',tochar(v_cam(1)),',',tochar(v_cam(2)),',',tochar(v_cam(3)),'>'
+        write(u,*) '  up <0,0.9,0>'
+        write(u,*) '  right <1.6,0,0>  // right,up -> 16:9'
+        write(u,*) '  look_at <0, 0, 0>'
+        write(u,*) '}'
+        v_up=[0,0,1]*1.0_flyt
+        v0=lo_cross(v_up,v_cam)
+        v0=v0/norm2(v0)+0.5_flyt*v_cam/norm2(v0)+v_up
+        v_light1=v0
+        v_light1=v_light1*10.0_flyt/norm2(v_light1)
+        ! Set the light source
+        write(u,*) 'light_source {'
+        write(u,*) '  <',tochar(v_light1(1)),',',tochar(v_light1(2)),',',tochar(v_light1(3)),'>'
+        write(u,*) '  color White'
+        write(u,*) '  area_light <.5, 0, 0>, <0, 0, .5>, 5, 5'
+        write(u,*) '  adaptive 1'
+        write(u,*) '  jitter'
+        write(u,*) '}'
+        write(u,*) 'light_source {'
+        write(u,*) '  <10, 20, 10>'
+        write(u,*) '  color Blue'
+        write(u,*) '  area_light <5, 0, 0>, <0, 0, 5>, 5, 5'
+        write(u,*) '  adaptive 1'
+        write(u,*) '  jitter'
+        write(u,*) '}'
+        write(u,*) ''
+
+        ! Now the header is done, with cameras and lights. Next up is defining the BZ, which
+        ! I do as both a polyhedron that is very transparent. Then I put tiny cylinders along the
+        ! edges. These cylinder reflect no light, and cast no shadow, so it looksjust like black lines.
+
+        ! define the BZ
+!        do i=1,uc%bz%nfaces
+!            write(u,*) 'polygon {'
+!            j=uc%bz%face(i)%n+1
+!            write(u,*) '    ',tochar(j),','
+!            write(u,"(4X)",advance='no')
+!            do j=1,uc%bz%face(i)%n
+!                write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') uc%bz%r(:,uc%bz%face(i)%ind(j))
+!            enddo
+!            write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')") uc%bz%r(:,uc%bz%face(i)%ind(1))
+!            write(u,*) '    texture { pigment { color BZCOLOR }}'
+!            write(u,*) '}'
+!        enddo
+        ! draw some cylinders along the edges
+        cylwidth=uc%bz%rmax/500.0_flyt
+        do i=1,uc%bz%nedges
+            write(u,*) 'cylinder {'
+            v0=uc%bz%r(:,uc%bz%edge(i)%i1)
+            v1=uc%bz%r(:,uc%bz%edge(i)%i2)
+            write(u,"(4X,'<',F11.6,',',F11.6,',',F11.6,'>,<',F11.6,',',F11.6,',',F11.6,'>,',F11.6)") v0,v1,cylwidth
+            write(u,*) '    texture { pigment { color Black } }'  
+            write(u,*) '    no_shadow' 
+            write(u,*) '}'
+        enddo
+
+        ! Now the idea is to dump triangles defining the phasespace surface. There are nb^3*2 phasespace surfaces for
+        ! each q, so we have to define which one to look for. That's done in the input with 6 integers per surface.
+        nsurf=size(modes_plusminus_clr_alpha,2)
+        do srf=1,nsurf
+            ! get the specification for this surface
+            if ( modes_plusminus_clr_alpha(4,srf) .eq. 0 ) then 
+                plus=.true.
+            else
+                plus=.false.
+            endif
+            b1=modes_plusminus_clr_alpha(1,srf)
+            b2=modes_plusminus_clr_alpha(2,srf)
+            b3=modes_plusminus_clr_alpha(3,srf)
+            ! define the color
+            i=modes_plusminus_clr_alpha(5,srf)
+            f0=( 100-modes_plusminus_clr_alpha(6,srf) )/100.0_flyt
+            select case(i)
+            case(1)
+                write(u,*) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.8,0.1,0.1,0,'//tochar(f0)//'>;'
+            case(2)
+                write(u,*) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.1,0.8,0.1,0,'//tochar(f0)//'>;'
+            case(3)
+                write(u,*) '#declare SFCOLOR'//tochar(srf)//' = rgbft<0.3,0.3,0.9,0,'//tochar(f0)//'>;'
+            end select
+
+            ! Dump the triangles that make up the surface
+            if ( plus ) then
+                ntri=ps%plus(b1,b2,b3)%ntri
+                npts=ps%plus(b1,b2,b3)%npts
+                if ( ntri .gt. 0 ) then
+                    ! print the mesh
+                    write(u,*) 'mesh {'
+                    do i=1,ntri
+                        ii=ps%plus(b1,b2,b3)%tri(1,i)
+                        jj=ps%plus(b1,b2,b3)%tri(2,i)
+                        kk=ps%plus(b1,b2,b3)%tri(3,i)
+                        v0=ps%plus(b1,b2,b3)%pts(:,ii) 
+                        v1=ps%plus(b1,b2,b3)%pts(:,jj) 
+                        v2=ps%plus(b1,b2,b3)%pts(:,kk)
+                        g0=ps%plus(b1,b2,b3)%grad(:,ii) 
+                        g1=ps%plus(b1,b2,b3)%grad(:,jj) 
+                        g2=ps%plus(b1,b2,b3)%grad(:,kk)
+                        !write(u,"(1X,A)",advance='no') 'triangle { '
+                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
+                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v1
+                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v2
+                        !write(u,*) '}'
+                        write(u,"(1X,A)",advance='no') 'smooth_triangle { '
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g0
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v1
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g1
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v2
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') g2
+                        write(u,*) '}'
+                    enddo
+                    write(u,*) '    texture { pigment { color SFCOLOR'//tochar(srf)//' }}'
+                    write(u,*) '    finish { ambient .4 diffuse .6 phong .2 }'
+                    write(u,*) '}'
+                endif
+            else
+                ntri=ps%minus(b1,b2,b3)%ntri
+                npts=ps%minus(b1,b2,b3)%npts
+                if ( ntri .gt. 0 ) then
+                    ! print the mesh
+                    write(u,*) 'mesh {'
+                    do i=1,ntri
+                        ii=ps%minus(b1,b2,b3)%tri(1,i)
+                        jj=ps%minus(b1,b2,b3)%tri(2,i)
+                        kk=ps%minus(b1,b2,b3)%tri(3,i)
+                        v0=ps%minus(b1,b2,b3)%pts(:,ii) 
+                        v1=ps%minus(b1,b2,b3)%pts(:,jj) 
+                        v2=ps%minus(b1,b2,b3)%pts(:,kk)
+                        g0=ps%minus(b1,b2,b3)%grad(:,ii) 
+                        g1=ps%minus(b1,b2,b3)%grad(:,jj) 
+                        g2=ps%minus(b1,b2,b3)%grad(:,kk)
+                        !write(u,"(1X,A)",advance='no') 'triangle { '
+                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
+                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v1
+                        !write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v2
+                        !write(u,*) '}'
+                        write(u,"(1X,A)",advance='no') 'smooth_triangle { '
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v0
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g0
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') v1
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') g1
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>,')",advance='no') v2
+                        write(u,"('<',F11.6,',',F11.6,',',F11.6,'>')",advance='no') g2
+                        write(u,*) '}'
+                    enddo
+                    write(u,*) '    texture { pigment { color SFCOLOR'//tochar(srf)//' }}'
+                    write(u,*) '    finish { ambient .4 diffuse .6 phong .2 }'
+                    write(u,*) '}'
+                endif
+            endif
+            !
+        enddo
+
+    close(u)
+
+end subroutine

--- a/tests/make_all_testfiles.sh
+++ b/tests/make_all_testfiles.sh
@@ -9,6 +9,7 @@ lineshape/
 pack_simulation/
 phonon_dispersion_relations/
 thermal_conductivity/
+phasespace_surface/
 "
 
 for folder in ${folders}

--- a/tests/phasespace_surface/00-ln_files.sh
+++ b/tests/phasespace_surface/00-ln_files.sh
@@ -1,0 +1,3 @@
+ln -sf ../infiles/infile.ucposcar
+ln -sf ../infiles/infile.forceconstant
+ln -sf ../infiles/infile.forceconstant_thirdorder

--- a/tests/phasespace_surface/01-run.sh
+++ b/tests/phasespace_surface/01-run.sh
@@ -1,0 +1,10 @@
+source 00-ln_files.sh
+
+
+phasespace_surface \
+        --verbose \
+	--qpoint_grid 11 11 11 \
+        --qpoint 0.0 0.0 1E-4 \
+	--intensities \
+        | tee phasespace_surface.log
+        # --povray \

--- a/tests/phasespace_surface/Makefile
+++ b/tests/phasespace_surface/Makefile
@@ -1,0 +1,7 @@
+testfiles:
+	bash 01-run.sh
+
+clean:
+	rm -f *.log
+	rm -f infile.*
+	rm -r __pycache__

--- a/tests/phasespace_surface/README.md
+++ b/tests/phasespace_surface/README.md
@@ -1,0 +1,3 @@
+There is a lot of degeneracy in the modes, we therefore allow for some deviation from the reference values. The number should be qualitatively the same.
+
+The reference data was generated with gfortran-13, O3

--- a/tests/phasespace_surface/reference/phasespace_surface.log
+++ b/tests/phasespace_surface/reference/phasespace_surface.log
@@ -1,0 +1,494 @@
+ ... read unitcell poscar
+ ... decided on Ewald lambda=0.67638  (0.00000s)
+ ... stored 531+725 lattice vectors (0.00037s)
+ ... Born charges already Hermitian
+ ... read second order forceconstant
+ ... read third order forceconstant
+ ... generate mesh
+  
+ Generating Brillouin zone mesh
+ ... building wedge mesh
+ ... built convex hull of wedge, got 6 points
+ ... calling CGAL to get raw tesselation
+ ... obtained raw set of points (0.13599s)
+ ... tesselating wedge mesh
+ ... triangulating
+ ... got 70 points and 138 tetrahedrons (0.00083s)
+ ... stored initial irreducible wedge (0.00007s)
+ ... no need to consider timereversal
+ ... constructed raw full set of 3360 points (0.00071s)
+  ... removing redundant points          100.0% |========================================|  0.00089s
+ ... got set of full points (0.00123s)
+ ... reduced from 3360 to 1579 points ( ~11.6^3  )
+ ... located irreducible in full mesh (0.00029s)
+  ... mapping grid indices               100.0% |========================================|  0.00089s
+ ... stored all symmetry operations (0.00011s)
+ ... set all integration weights (0.00008s)
+ ... preparing weights, reduced from 1579 to 1146 points
+ ... pre-processed points (0.00053s)
+ ... transformed points (0.00007s)
+ ... decided on box division:  -1 -1 -1 (0.00017s)
+  ... distancetable                      100.0% |========================================|  0.00496s
+  ... voronoi tesselation                100.0% |========================================|  0.00441s
+ ... sum weights:  0.99999999999999711     
+ Done building mesh (0.15164s)
+ 
+ Calculating isosurfaces
+ ... made some initial space
+ ... got energies at nodes
+ ... ntri =         2352        2238 , calculate intensities
+ *** small omega in scattering amplitude, set to 0
+ ... found         1146  points.
+ ... max(abs(psisq)) =     0.11968E-03
+ ... psisq_norm      =     0.55213E-03
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.67633E-09
+ ... psisq_norm      =     0.20184E-08
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          264         264 , calculate intensities
+ ... found          134  points.
+ ... max(abs(psisq)) =     0.12521E-03
+ ... psisq_norm      =     0.46095E-03
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =           48          48 , calculate intensities
+ ... found           56  points.
+ ... max(abs(psisq)) =     0.25666E-08
+ ... psisq_norm      =     0.78174E-08
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2256        2256 , calculate intensities
+ ... found         1148  points.
+ ... max(abs(psisq)) =     0.42096E-03
+ ... psisq_norm      =     0.22106E-02
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.55484E-11
+ ... psisq_norm      =     0.11107E-10
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2256        2190 , calculate intensities
+ ... found         1145  points.
+ ... max(abs(psisq)) =     0.39166E-04
+ ... psisq_norm      =     0.27123E-03
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.85515E-09
+ ... psisq_norm      =     0.20184E-08
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          264         264 , calculate intensities
+ ... found          134  points.
+ ... max(abs(psisq)) =     0.48895E-03
+ ... psisq_norm      =     0.12958E-02
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =           48          48 , calculate intensities
+ ... found           56  points.
+ ... max(abs(psisq)) =     0.18850E-08
+ ... psisq_norm      =     0.71131E-08
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2256        2256 , calculate intensities
+ ... found         1148  points.
+ ... max(abs(psisq)) =     0.61361E-03
+ ... psisq_norm      =     0.17246E-02
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.64169E-11
+ ... psisq_norm      =     0.11107E-10
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =           48           0 , calculate intensities
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ ... found           26  points.
+ ... max(abs(psisq)) =     0.00000E+00
+ ... psisq_norm      =     0.00000E+00
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2304        2304 , calculate intensities
+ ... found         1188  points.
+ ... max(abs(psisq)) =     0.73981E-04
+ ... psisq_norm      =     0.41191E-03
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =           48           0 , calculate intensities
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ ... found           26  points.
+ ... max(abs(psisq)) =     0.00000E+00
+ ... psisq_norm      =     0.00000E+00
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =           48           0 , calculate intensities
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ ... found           26  points.
+ ... max(abs(psisq)) =     0.00000E+00
+ ... psisq_norm      =     0.00000E+00
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =           48           0 , calculate intensities
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ *** small omega in scattering amplitude, set to 0
+ ... found           26  points.
+ ... max(abs(psisq)) =     0.00000E+00
+ ... psisq_norm      =     0.00000E+00
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.93619E-12
+ ... psisq_norm      =     0.24430E-11
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =           48          48 , calculate intensities
+ ... found           56  points.
+ ... max(abs(psisq)) =     0.23790E-08
+ ... psisq_norm      =     0.90415E-08
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2256        2256 , calculate intensities
+ ... found         1148  points.
+ ... max(abs(psisq)) =     0.32436E-03
+ ... psisq_norm      =     0.16802E-02
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.24048E-11
+ ... psisq_norm      =     0.70200E-11
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1632        1632 , calculate intensities
+ ... found          818  points.
+ ... max(abs(psisq)) =     0.12490E-07
+ ... psisq_norm      =     0.58265E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1584        1584 , calculate intensities
+ ... found          794  points.
+ ... max(abs(psisq)) =     0.14415E-07
+ ... psisq_norm      =     0.66714E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.74366E-08
+ ... psisq_norm      =     0.12616E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.15658E-07
+ ... psisq_norm      =     0.22903E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1584        1584 , calculate intensities
+ ... found          794  points.
+ ... max(abs(psisq)) =     0.33109E-07
+ ... psisq_norm      =     0.74556E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1632        1632 , calculate intensities
+ ... found          818  points.
+ ... max(abs(psisq)) =     0.73964E-07
+ ... psisq_norm      =     0.33694E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.29212E-07
+ ... psisq_norm      =     0.20506E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.48256E-07
+ ... psisq_norm      =     0.13644E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.11213E-07
+ ... psisq_norm      =     0.14182E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.29205E-07
+ ... psisq_norm      =     0.20474E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.17308E-06
+ ... psisq_norm      =     0.10775E-05
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.25910E-07
+ ... psisq_norm      =     0.16017E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1632        1632 , calculate intensities
+ ... found          818  points.
+ ... max(abs(psisq)) =     0.37502E-07
+ ... psisq_norm      =     0.96339E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1584        1584 , calculate intensities
+ ... found          794  points.
+ ... max(abs(psisq)) =     0.16148E-07
+ ... psisq_norm      =     0.61095E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.11227E-07
+ ... psisq_norm      =     0.16519E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.16690E-07
+ ... psisq_norm      =     0.33479E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1584        1584 , calculate intensities
+ ... found          794  points.
+ ... max(abs(psisq)) =     0.16145E-07
+ ... psisq_norm      =     0.62750E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1632        1632 , calculate intensities
+ ... found          818  points.
+ ... max(abs(psisq)) =     0.71527E-07
+ ... psisq_norm      =     0.30647E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.44778E-07
+ ... psisq_norm      =     0.23694E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.37873E-07
+ ... psisq_norm      =     0.10706E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.88001E-08
+ ... psisq_norm      =     0.10564E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          912         912 , calculate intensities
+ ... found          458  points.
+ ... max(abs(psisq)) =     0.44778E-07
+ ... psisq_norm      =     0.23704E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.22053E-06
+ ... psisq_norm      =     0.10746E-05
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          528         528 , calculate intensities
+ ... found          266  points.
+ ... max(abs(psisq)) =     0.36871E-07
+ ... psisq_norm      =     0.20011E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.74523E-07
+ ... psisq_norm      =     0.88823E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2640        2640 , calculate intensities
+ ... found         1712  points.
+ ... max(abs(psisq)) =     0.19343E-07
+ ... psisq_norm      =     0.20813E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2976        2976 , calculate intensities
+ ... found         1788  points.
+ ... max(abs(psisq)) =     0.39622E-07
+ ... psisq_norm      =     0.39755E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         3024        3024 , calculate intensities
+ ... found         1628  points.
+ ... max(abs(psisq)) =     0.28994E-07
+ ... psisq_norm      =     0.16668E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2376        2352 , calculate intensities
+ ... found         1322  points.
+ ... max(abs(psisq)) =     0.75280E-07
+ ... psisq_norm      =     0.88634E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1440        1440 , calculate intensities
+ ... found          722  points.
+ ... max(abs(psisq)) =     0.15501E-07
+ ... psisq_norm      =     0.95810E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1104        1104 , calculate intensities
+ ... found          554  points.
+ ... max(abs(psisq)) =     0.15498E-07
+ ... psisq_norm      =     0.66570E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =          144         144 , calculate intensities
+ ... found          168  points.
+ ... max(abs(psisq)) =     0.74527E-07
+ ... psisq_norm      =     0.88823E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2976        2976 , calculate intensities
+ ... found         1788  points.
+ ... max(abs(psisq)) =     0.39620E-07
+ ... psisq_norm      =     0.39755E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1440        1440 , calculate intensities
+ ... found          722  points.
+ ... max(abs(psisq)) =     0.14876E-07
+ ... psisq_norm      =     0.95627E-07
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         2640        2640 , calculate intensities
+ ... found         1712  points.
+ ... max(abs(psisq)) =     0.19343E-07
+ ... psisq_norm      =     0.20813E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         3024        3024 , calculate intensities
+ ... found         1628  points.
+ ... max(abs(psisq)) =     0.29012E-07
+ ... psisq_norm      =     0.16668E-06
+  ... calculating intensities            100.0% |========================================| 
+ ... ntri =         1104        1104 , calculate intensities
+ ... found          554  points.
+ ... max(abs(psisq)) =     0.14579E-07
+ ... psisq_norm      =     0.64369E-07
+  ... calculating intensities            100.0% |========================================| 
+  ... isosurfaces                        100.0% |========================================| 
+ ... got isosurfaces
+ ... got aligned triangles
+ ... write nonzero phase spaces and scattering intensities
+ plus
+                   1                   1                   2                2238    0.5521265083E-03
+                   1                   2                   3                 144    0.2018369778E-08
+                   1                   3                   3                 264    0.4609524483E-03
+                   1                   3                   4                  48    0.7817399451E-08
+                   1                   4                   5                2256    0.2210645496E-02
+                   1                   5                   6                 144    0.1110715798E-10
+                   2                   1                   2                2190    0.2712257080E-03
+                   2                   2                   3                 144    0.2018380655E-08
+                   2                   3                   3                 264    0.1295831264E-02
+                   2                   3                   4                  48    0.7113106482E-08
+                   2                   4                   5                2256    0.1724630052E-02
+                   2                   5                   6                 144    0.1110736043E-10
+                   3                   1                   2                2304    0.4119116964E-03
+                   3                   2                   3                 144    0.2443036257E-11
+                   3                   3                   4                  48    0.9041509094E-08
+                   3                   4                   5                2256    0.1680210466E-02
+                   3                   5                   6                 144    0.7019965617E-11
+                   4                   1                   6                 528    0.2290316742E-07
+                   4                   2                   6                 528    0.1364369414E-06
+                   4                   3                   6                 528    0.1601688932E-06
+                   5                   1                   6                 528    0.3347926361E-07
+                   5                   2                   6                 528    0.1070571153E-06
+                   5                   3                   6                 528    0.2001093413E-06
+ minus
+                   4                   1                   1                1632    0.5826460969E-07
+                   4                   1                   2                1584    0.6671431853E-07
+                   4                   1                   3                 912    0.1261648526E-07
+                   4                   2                   1                1584    0.7455642249E-07
+                   4                   2                   2                1632    0.3369401445E-06
+                   4                   2                   3                 912    0.2050555859E-06
+                   4                   3                   1                 912    0.1418184704E-07
+                   4                   3                   2                 912    0.2047383401E-06
+                   4                   3                   3                 528    0.1077462204E-05
+                   5                   1                   1                1632    0.9633927368E-07
+                   5                   1                   2                1584    0.6109471325E-07
+                   5                   1                   3                 912    0.1651904110E-07
+                   5                   2                   1                1584    0.6274997055E-07
+                   5                   2                   2                1632    0.3064658497E-06
+                   5                   2                   3                 912    0.2369390433E-06
+                   5                   3                   1                 912    0.1056364983E-07
+                   5                   3                   2                 912    0.2370440201E-06
+                   5                   3                   3                 528    0.1074622028E-05
+                   6                   1                   4                 144    0.8882294461E-06
+                   6                   1                   5                2640    0.2081304002E-06
+                   6                   2                   4                2976    0.3975489743E-06
+                   6                   2                   5                3024    0.1666772888E-06
+                   6                   3                   3                2352    0.8863427449E-06
+                   6                   3                   4                1440    0.9580960367E-07
+                   6                   3                   5                1104    0.6657035523E-07
+                   6                   4                   1                 144    0.8882302740E-06
+                   6                   4                   2                2976    0.3975488005E-06
+                   6                   4                   3                1440    0.9562686038E-07
+                   6                   5                   1                2640    0.2081307254E-06
+                   6                   5                   2                3024    0.1666797442E-06
+                   6                   5                   3                1104    0.6436916203E-07
+ All done in 14.10472s

--- a/tests/phasespace_surface/test_phasespace_surface.py
+++ b/tests/phasespace_surface/test_phasespace_surface.py
@@ -1,0 +1,57 @@
+import numpy as np
+from pathlib import Path
+
+parent = Path(__file__).parent
+folder = parent / "reference"
+
+
+def _read_file(file):
+    data_plus = []
+    data_minus = []
+    with open(file, "r") as f:
+        for line in f:
+            if "... write nonzero phase spaces and scattering intensities" in line:
+                break
+
+        for line in f:
+            if "plus" in line:
+                _plus = True
+                continue
+            if "minus" in line:
+                _plus = False
+                continue
+            if "All done" in line:
+                return np.array(data_plus), np.array(data_minus)
+
+            x1, x2, x3, x4, x5 = line.split()
+            if _plus:
+                data_plus.append([int(x1), int(x2), int(x3), int(x4), float(x5)])
+            else:
+                data_minus.append([int(x1), int(x2), int(x3), int(x4), float(x5)])
+
+
+def test_phasespace(file="phasespace_surface.log"):
+    data_ref = _read_file(folder / file)
+    data_new = _read_file(parent / file)
+
+    err_msg = (parent / file).absolute()
+    # 3 modes: should match exactly
+    kw = {"err_msg": err_msg}
+    np.testing.assert_allclose(data_ref[0][:, :3], data_new[0][:, :3], **kw)
+    np.testing.assert_allclose(data_ref[1][:, :3], data_new[1][:, :3], **kw)
+
+    # 4: number of points: should match up to 10% error
+    rtol = 1
+    kw = {"atol": 0, "rtol": rtol, "err_msg": err_msg}
+    np.testing.assert_allclose(data_ref[0][:, 3], data_new[0][:, 3], **kw)
+    np.testing.assert_allclose(data_ref[1][:, 3], data_new[1][:, 3], **kw)
+
+    # 5: intensity: should match up to 0.01
+    atol = 1e-2
+    kw = {"atol": atol, "rtol": 0, "err_msg": err_msg}
+    np.testing.assert_allclose(data_ref[0][:, 4], data_new[0][:, 4], **kw)
+    np.testing.assert_allclose(data_ref[1][:, 4], data_new[1][:, 4], **kw)
+
+
+if __name__ == "__main__":
+    test_phasespace()


### PR DESCRIPTION
Recall `phasespace_surface` to life

This PR adds `phasespace_surface` back, makes it compile with CGAL 5 and adds some extra options and output.

See details on how to compile with CGAL: https://github.com/tdep-developers/tdep/wiki/CGAL-support