### PR TITLE
Adding references for off-diagonal thermal conductivity (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ and the respective publications for the algorithms that were used:
 
 - Implementation: [O. Hellman and D.A. Broido, Phys. Rev. B **90**, 134309 (2014)](https://dx.doi.org/10.1103/physrevb.90.134309)
 - Fourth order contributions: [J. Klarbring *et al.*, Phys Rev Lett **125**, 045701 (2020)](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.125.045701)
+- Off diagonal contributions: [Simoncelli, M. & Marzari, N. & Mauri, F. (2019), Nat. Phys. **15** 803-819](https://doi.org/10.1038/s41567-019-0520-x), [Isaeva, L & Barbalinardo, G. & Donadio, D. & Baroni, S., Nat. Comm. **10** 3853 (2019)](https://doi.org/10.1038/s41467-019-11572-4), [Fiorentino, A. & Baroni, S, Phys. Rev. B, **107**, 054311 (2023)](https://doi.org/10.1103/PhysRevB.107.054311)
 
 `lineshape`
 

--- a/docs/program/thermal_conductivity.md
+++ b/docs/program/thermal_conductivity.md
@@ -741,7 +741,7 @@ $$
 $$
 
 where $\kappa_{\alpha\beta}^{\mathrm{BTE}}$ is the thermal conductivity from the previous section and $\kappa_{\alpha\beta}^{c}$ is the off-diagonal coherent contribution.
-This term is computed as
+This term is computed as (eq. 22-24 in [^Fiorentino2023])
 
 $$
 \begin{equation}

--- a/src/thermal_conductivity/main.f90
+++ b/src/thermal_conductivity/main.f90
@@ -326,6 +326,8 @@ finalize_and_write: block
         write (*, '(1X,A41,A43)') 'Iterative Boltzmann transport equation : ', 'M. Omini et al., Phys Rev B 53, 9064 (1996)'
         write (*, '(1X,A41,A49)') 'Algorithm : ', 'A. H. Romero et al., Phys Rev B 91, 214310 (2015)'
         write (*, '(1X,A41,A43)') 'Off diagonal coherent contribution : ', 'L. Isaeva et al., Nat Commun 10 3853 (2019)'
+        write (*, '(1X,A41,A49)') '                                     ', 'M. Simoncelli et al., Nat Phys 15 809-813  (2019)'
+        write (*, '(1X,A41,A52)') '                                     ', 'A. Fiorentino et al., Phys Rev B 107, 054311  (2023)'
 
         t0 = timer_init + timer_count + timer_matrixelements + timer_qs + timer_kappa + timer_scf + timer_cumulative
         write (*, *) ' '


### PR DESCRIPTION
The references are added in the README and the output, and the fact that we use eq. 22-24 from Fiorentino is explained in the doc.
The standard output looks like

``` Suggested citations :
                               Software : F. Knoop et al., J. Open Source Softw 9(94), 6150 (2024)
                                 Method : D. A. Broido et al., Appl Phys Lett 91, 231922 (2007)
 Iterative Boltzmann transport equation : M. Omini et al., Phys Rev B 53, 9064 (1996)
                              Algorithm : A. H. Romero et al., Phys Rev B 91, 214310 (2015)
     Off diagonal coherent contribution : M. Simoncelli et al., Nat Phys 15 809-813  (2019)
                                          L. Isaeva et al., Nat Commun 10 3853 (2019)
                                          A. Fiorentino et al., Phys Rev B 107, 054311  (2023)
```