### PR TITLE
Write dispersion on irreducible grid to HDF5

### DIFF
--- a/src/libolle/type_phonon_dispersions.f90
+++ b/src/libolle/type_phonon_dispersions.f90
@@ -140,6 +140,8 @@ contains
     procedure :: thermal_displacement_matrix
     !> store the full grid in a hdf file
     procedure :: write_to_hdf5
+    !> store the irreducible grid in a hdf5 file
+    procedure :: write_irreducible_to_hdf5
     !> make sure things that are supposed to be degenerate really are
     procedure :: enforce_degeneracy
     !> communication helper
@@ -626,6 +628,109 @@ subroutine write_to_hdf5(dr, qp, uc, filename, mem, temperature)
         call h5%store_data(dd, h5%file_id, trim(dname), enhet='J/K', dimensions='q-vector,mode')
         call mem%deallocate(dd, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     end if
+
+    call h5%close_file()
+    call h5%destroy(__FILE__, __LINE__)
+end subroutine
+
+!> write the dispersion on the irreducible mesh to a hdf5 file
+subroutine write_irreducible_to_hdf5(dr, qp, uc, filename, mem)
+    !> phonon dispersions
+    class(lo_phonon_dispersions), intent(in) :: dr
+    !> q-point mesh
+    class(lo_qpoint_mesh), intent(in) :: qp
+    !> crystal structure
+    type(lo_crystalstructure), intent(in) :: uc
+    !> filename
+    character(len=*), intent(in) :: filename
+    !> memory tracker
+    type(lo_mem_helper), intent(inout) :: mem
+
+    type(lo_hdf5_helper) :: h5
+    real(r8), dimension(:, :, :, :), allocatable :: dddd
+    real(r8), dimension(:, :, :), allocatable :: ddd
+    real(r8), dimension(:, :), allocatable :: dd
+    real(r8), dimension(:), allocatable :: di
+    real(r8), dimension(3) :: v0, v1
+    real(r8) :: n1, n, f0, omega, cv, tau
+    integer :: i, j, k, l
+    character(len=1000) :: dname
+
+    call h5%init(__FILE__, __LINE__)
+    call h5%open_file('write', trim(filename))
+
+    ! Some general attributes first:
+    call h5%store_attribute(dr%n_mode/3, h5%file_id, 'number_of_atoms', lo_status)
+    call h5%store_attribute(dr%n_mode, h5%file_id, 'number_of_bands', lo_status)
+    call h5%store_attribute(dr%n_irr_qpoint, h5%file_id, 'number_of_qpoints', lo_status)
+    select type (qp)
+    type is (lo_monkhorst_pack_mesh)
+        call h5%store_attribute('Monkhorst-Pack', h5%file_id, 'meshtype', lo_status)
+    type is (lo_fft_mesh)
+        call h5%store_attribute('FFT', h5%file_id, 'meshtype', lo_status)
+    type is (lo_wedge_mesh)
+        call h5%store_attribute('Wedge', h5%file_id, 'meshtype', lo_status)
+    end select
+
+    ! q-points
+    dname = 'qpoints'
+    call mem%allocate(dd, [3, qp%n_irr_point], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    do i = 1, qp%n_irr_point
+        dd(:, i) = qp%ip(i)%r
+    end do
+    call h5%store_data(dd, h5%file_id, trim(dname), enhet='1/A', dimensions='q-vector,xyz')
+    call mem%deallocate(dd, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+
+    ! frequencies
+    if (allocated(dr%iq(1)%omega)) then
+        dname = 'frequencies'
+        call mem%allocate(dd, [dr%n_mode, qp%n_irr_point], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        do i = 1, qp%n_irr_point
+            dd(:, i) = dr%iq(i)%omega*lo_frequency_hartree_to_Hz
+        end do
+        call h5%store_data(dd, h5%file_id, trim(dname), enhet='Hz (angular)', dimensions='q-vector,mode')
+        call mem%deallocate(dd, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    end if
+
+    ! Group velocities
+    if (allocated(dr%iq(1)%vel)) then
+        dname = 'group_velocities'
+        call mem%allocate(ddd, [3, dr%n_mode, qp%n_irr_point], &
+                          persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        do i = 1, qp%n_irr_point
+            ddd(:, :, i) = dr%iq(i)%vel*lo_groupvel_hartreebohr_to_ms
+        end do
+        call h5%store_data(ddd, h5%file_id, trim(dname), enhet='m/s', dimensions='q-vector,mode,xyz')
+        call mem%deallocate(ddd, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    end if
+
+    ! Gruneisen parameters
+    if (allocated(dr%iq(1)%gruneisen)) then
+        dname = 'gruneisen_parameters'
+        call mem%allocate(dd, [dr%n_mode, qp%n_irr_point], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        do i = 1, qp%n_irr_point
+            dd(:, i) = dr%iq(i)%gruneisen
+        end do
+        call h5%store_data(dd, h5%file_id, trim(dname), enhet='dimensionless', dimensions='q-vector,mode')
+        call mem%deallocate(dd, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    end if
+
+    ! unit cell vectors
+    dname = 'lattice_vectors'
+    call mem%allocate(dd, [3, 3], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    ! TODO: check transposition convention for lattice vectors
+    dd = lo_bohr_to_m*1.d10*transpose(uc%latticevectors)
+    call h5%store_data(dd, h5%file_id, trim(dname), enhet='A', dimensions='xyz,xyz')
+    call mem%deallocate(dd, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+
+    ! integration weights
+    dname = 'integration_weights'
+    call mem%allocate(di, qp%n_irr_point, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    do i = 1, qp%n_irr_point
+        di(i) = qp%ip(i)%integration_weight
+    end do
+    call h5%store_data(di, h5%file_id, trim(dname), enhet='1', dimensions='q-vector')
+    call mem%deallocate(di, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
 
     call h5%close_file()
     call h5%destroy(__FILE__, __LINE__)

--- a/src/libolle/type_phonon_dos.f90
+++ b/src/libolle/type_phonon_dos.f90
@@ -4,18 +4,18 @@ module type_phonon_dos
 !! In addition, we can also get other quantities frequency-resolved and projected, while
 !! we are doing it.
 !!
-use konstanter, only: r8,i8,lo_huge,lo_hugeint,lo_freqtol,lo_status,lo_twopi,lo_pi,lo_tol,lo_exitcode_param,&
-                      lo_gnuplotterminal,lo_frequency_hartree_to_icm,lo_frequency_hartree_to_thz,&
-                      lo_frequency_hartree_to_mev,lo_sqtol
-use gottochblandat, only: open_file,walltime,lo_gauss,lo_trueNtimes,lo_trapezoid_integration,tochar,lo_linspace,&
-                          lo_progressbar_init,lo_progressbar,lo_chop,lo_mean
-use mpi_wrappers, only: lo_mpi_helper,lo_stop_gracefully
+use konstanter, only: r8, i8, lo_huge, lo_hugeint, lo_freqtol, lo_status, lo_twopi, lo_pi, lo_tol, lo_exitcode_param, &
+                      lo_gnuplotterminal, lo_frequency_hartree_to_icm, lo_frequency_hartree_to_thz, &
+                      lo_frequency_hartree_to_mev, lo_sqtol
+use gottochblandat, only: open_file, walltime, lo_gauss, lo_trueNtimes, lo_trapezoid_integration, tochar, lo_linspace, &
+                          lo_progressbar_init, lo_progressbar, lo_chop, lo_mean
+use mpi_wrappers, only: lo_mpi_helper, lo_stop_gracefully
 use lo_memtracker, only: lo_mem_helper
 use hdf5_wrappers, only: lo_hdf5_helper
 use dump_data, only: lo_dump_palette_to_gnuplot
 use type_crystalstructure, only: lo_crystalstructure
 use type_phonon_dispersions, only: lo_phonon_dispersions
-use type_qpointmesh, only: lo_qpoint_mesh,lo_integration_weights_for_one_tetrahedron,lo_LV_tetrahedron_weights
+use type_qpointmesh, only: lo_qpoint_mesh, lo_integration_weights_for_one_tetrahedron, lo_LV_tetrahedron_weights
 
 implicit none
 private
@@ -24,47 +24,47 @@ public :: lo_phonon_dos
 !> Phonon density of states
 type lo_phonon_dos
     !> number of dos-points
-    integer :: n_dos_point=-lo_hugeint
+    integer :: n_dos_point = -lo_hugeint
     !> number of atoms
-    integer :: n_atom=-lo_hugeint
+    integer :: n_atom = -lo_hugeint
     !> number of modes
-    integer :: n_mode=-lo_hugeint
+    integer :: n_mode = -lo_hugeint
     !> the frequency axis
     real(r8), dimension(:), allocatable :: omega
     !> the DOS
     real(r8), dimension(:), allocatable :: dos
     !> site projected density of states
-    real(r8), dimension(:,:), allocatable :: pdos_site
+    real(r8), dimension(:, :), allocatable :: pdos_site
     !> mode projected density of states
-    real(r8), dimension(:,:), allocatable :: pdos_mode
+    real(r8), dimension(:, :), allocatable :: pdos_mode
     !> maximum frequency
-    real(r8) :: dosmax=-lo_huge
+    real(r8) :: dosmax = -lo_huge
     !> minimum frequency
-    real(r8) :: dosmin=-lo_huge
+    real(r8) :: dosmin = -lo_huge
     !> which integration scheme to use
-    integer :: integrationtype=-lo_hugeint
+    integer :: integrationtype = -lo_hugeint
     !> Should I add a prefactor to the default smearing
-    real(r8) :: smearing_prefactor=-lo_huge
-    contains
-        !> Calculate the DOS
-        procedure :: generate
-        !> Calculate spectral thermal conductivity
-        procedure :: spectral_kappa
-        !> Calculate spectral angular momentum
-        procedure :: spectral_angular_momentum
-        !> dump it to file
-        procedure :: write_to_file
-        !> dump it to hdf5
-        procedure :: write_to_hdf5
-        !> size in memory
-        procedure :: size_in_mem=>phonon_dos_size_in_mem
-        !> destroy the phonon dos
-        procedure :: destroy
+    real(r8) :: smearing_prefactor = -lo_huge
+contains
+    !> Calculate the DOS
+    procedure :: generate
+    !> Calculate spectral thermal conductivity
+    procedure :: spectral_kappa
+    !> Calculate spectral angular momentum
+    procedure :: spectral_angular_momentum
+    !> dump it to file
+    procedure :: write_to_file
+    !> dump it to hdf5
+    procedure :: write_to_hdf5
+    !> size in memory
+    procedure :: size_in_mem => phonon_dos_size_in_mem
+    !> destroy the phonon dos
+    procedure :: destroy
 end type
 
 ! interfaces to type_phonon_dos_integrations
 interface
-    module subroutine lo_get_phonon_dos_tetrahedron(pd,qp,dr,mw,mem,verbosity)
+    module subroutine lo_get_phonon_dos_tetrahedron(pd, qp, dr, mw, mem, verbosity)
         type(lo_phonon_dos), intent(inout) :: pd
         type(lo_qpoint_mesh), intent(in) :: qp
         type(lo_phonon_dispersions), intent(in) :: dr
@@ -72,25 +72,25 @@ interface
         type(lo_mem_helper), intent(inout) :: mem
         integer, intent(in) :: verbosity
     end subroutine
-    module subroutine lo_get_phonon_dos_gaussian(pd,qp,dr,mw,verbosity)
+    module subroutine lo_get_phonon_dos_gaussian(pd, qp, dr, mw, verbosity)
         type(lo_phonon_dos), intent(inout) :: pd
         class(lo_qpoint_mesh), intent(in) :: qp
         type(lo_phonon_dispersions), intent(in) :: dr
         type(lo_mpi_helper), intent(inout) :: mw
         integer, intent(in) :: verbosity
     end subroutine
-    module subroutine spectral_kappa(pd,uc,qp,dr,mw,mem,spec_kappa,spec_kappa_band,spec_kappa_atom)
+    module subroutine spectral_kappa(pd, uc, qp, dr, mw, mem, spec_kappa, spec_kappa_band, spec_kappa_atom)
         class(lo_phonon_dos), intent(inout) :: pd
         type(lo_crystalstructure), intent(in) :: uc
         type(lo_qpoint_mesh), intent(in) :: qp
         type(lo_phonon_dispersions), intent(in) :: dr
         type(lo_mpi_helper), intent(inout) :: mw
         type(lo_mem_helper), intent(inout) :: mem
-        real(r8), dimension(:,:), allocatable, intent(out) :: spec_kappa
-        real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_kappa_band
-        real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_kappa_atom
+        real(r8), dimension(:, :), allocatable, intent(out) :: spec_kappa
+        real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_kappa_band
+        real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_kappa_atom
     end subroutine
-    module subroutine spectral_angular_momentum(pd,uc,qp,dr,temperature,mw,mem,spec_angmom,spec_angmom_band,spec_angmom_atom)
+    module subroutine spectral_angular_momentum(pd, uc, qp, dr, temperature, mw, mem, spec_angmom, spec_angmom_band, spec_angmom_atom)
         class(lo_phonon_dos), intent(inout) :: pd
         type(lo_crystalstructure), intent(in) :: uc
         type(lo_qpoint_mesh), intent(in) :: qp
@@ -98,16 +98,16 @@ interface
         real(r8), intent(in) :: temperature
         type(lo_mpi_helper), intent(inout) :: mw
         type(lo_mem_helper), intent(inout) :: mem
-        real(r8), dimension(:,:), allocatable, intent(out) :: spec_angmom
-        real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_angmom_band
-        real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_angmom_atom
+        real(r8), dimension(:, :), allocatable, intent(out) :: spec_angmom
+        real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_angmom_band
+        real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_angmom_atom
     end subroutine
 end interface
 
 contains
 
 !> Calculate the phonon density of states
-subroutine generate(pd,dr,qp,uc,mw,mem,verbosity,sigma,n_dos_point,integrationtype)
+subroutine generate(pd, dr, qp, uc, mw, mem, verbosity, sigma, n_dos_point, integrationtype)
     !> The phonon dos
     class(lo_phonon_dos), intent(inout) :: pd
     !> the dispersion relations
@@ -129,175 +129,175 @@ subroutine generate(pd,dr,qp,uc,mw,mem,verbosity,sigma,n_dos_point,integrationty
     !> set the integration type
     integer, intent(in), optional :: integrationtype
 
-    real(r8) :: timer,t0,t1
+    real(r8) :: timer, t0, t1
 
     ! Set some basic things, defaults and such
     init: block
         integer :: i
 
-        if ( verbosity .gt. 0 ) then
-            timer=walltime()
-            t0=timer
-            t1=0.0_r8
-            write(*,*) ''
-            write(*,*) 'Calculating phonon density of states'
-        endif
+        if (verbosity .gt. 0) then
+            timer = walltime()
+            t0 = timer
+            t1 = 0.0_r8
+            write (*, *) ''
+            write (*, *) 'Calculating phonon density of states'
+        end if
 
         ! Sort out the integration type
-        if ( present(integrationtype) ) then
-            pd%integrationtype=integrationtype
+        if (present(integrationtype)) then
+            pd%integrationtype = integrationtype
         else
-            pd%integrationtype=2
-        endif
+            pd%integrationtype = 2
+        end if
 
         ! Sort out smearing
-        if ( present(sigma) ) then
-            pd%smearing_prefactor=sigma
+        if (present(sigma)) then
+            pd%smearing_prefactor = sigma
         else
-            pd%smearing_prefactor=1.0_r8
-        endif
+            pd%smearing_prefactor = 1.0_r8
+        end if
 
         ! Number of points in the density of states.
-        if ( present(n_dos_point) ) then
-            pd%n_dos_point=n_dos_point
+        if (present(n_dos_point)) then
+            pd%n_dos_point = n_dos_point
         else
-            pd%n_dos_point=1000
-        endif
+            pd%n_dos_point = 1000
+        end if
 
         ! Choose the smallest frequency so that imaginary things will show
-        pd%dosmin=lo_huge
-        do i=1,dr%n_irr_qpoint
-            pd%dosmin=min(pd%dosmin,minval(dr%iq(i)%omega))
-        enddo
-        if ( pd%dosmin .gt. -lo_freqtol ) pd%dosmin=0.0_r8
+        pd%dosmin = lo_huge
+        do i = 1, dr%n_irr_qpoint
+            pd%dosmin = min(pd%dosmin, minval(dr%iq(i)%omega))
+        end do
+        if (pd%dosmin .gt. -lo_freqtol) pd%dosmin = 0.0_r8
         ! and the largest frequency is quite straightforward
-        pd%dosmax=dr%omega_max+4.01_r8*maxval(dr%default_smearing)
+        pd%dosmax = dr%omega_max + 4.01_r8*maxval(dr%default_smearing)
 
         ! use the min and max to get the frequency axis
-        allocate(pd%omega(pd%n_dos_point))
-        call lo_linspace(pd%dosmin,pd%dosmax,pd%omega)
+        allocate (pd%omega(pd%n_dos_point))
+        call lo_linspace(pd%dosmin, pd%dosmax, pd%omega)
         ! and space for the actual density of states
-        pd%n_mode=dr%n_mode
-        pd%n_atom=uc%na
-        allocate(pd%dos(pd%n_dos_point))
-        allocate(pd%pdos_site(pd%n_dos_point,pd%n_atom))
-        allocate(pd%pdos_mode(pd%n_dos_point,pd%n_mode))
-        pd%dos=0.0_r8
-        pd%pdos_site=0.0_r8
-        pd%pdos_mode=0.0_r8
+        pd%n_mode = dr%n_mode
+        pd%n_atom = uc%na
+        allocate (pd%dos(pd%n_dos_point))
+        allocate (pd%pdos_site(pd%n_dos_point, pd%n_atom))
+        allocate (pd%pdos_mode(pd%n_dos_point, pd%n_mode))
+        pd%dos = 0.0_r8
+        pd%pdos_site = 0.0_r8
+        pd%pdos_mode = 0.0_r8
     end block init
 
     ! Call the actual integration to get a raw, not so pretty DOS
     integrate: block
-        select case( pd%integrationtype )
-            case(1)
-                if ( verbosity .gt. 0 ) then
+        select case (pd%integrationtype)
+        case (1)
+            if (verbosity .gt. 0) then
 
-                    write(*,"(1X,A)") '... fix gaussian integration, sigma = '//tochar(lo_mean(dr%default_smearing)*pd%smearing_prefactor*lo_Frequency_Hartree_to_THz)//' THz, N energy points: '//tochar(pd%n_dos_point)
-                endif
-                call lo_get_phonon_dos_gaussian(pd,qp,dr,mw,verbosity)
-            case(2)
-                if ( verbosity .gt. 0 ) then
-                    write(*,"(1X,A)") '... adaptive gaussian integration, scalingfactor = '//tochar(pd%smearing_prefactor)//', N energy points: '//tochar(pd%n_dos_point)
-                endif
-                call lo_get_phonon_dos_gaussian(pd,qp,dr,mw,verbosity)
-            case(3)
-                if ( verbosity .gt. 0 ) then
-                    write(*,"(1X,A)") '... tetrahedron integration, N energy points: '//tochar(pd%n_dos_point)
-                endif
-                call lo_get_phonon_dos_tetrahedron(pd,qp,dr,mw,mem,verbosity)
-            case default
-                write(*,*) 'unknown integration type'
-                stop
+                write (*, "(1X,A)") '... fix gaussian integration, sigma = '//tochar(lo_mean(dr%default_smearing)*pd%smearing_prefactor*lo_Frequency_Hartree_to_THz)//' THz, N energy points: '//tochar(pd%n_dos_point)
+            end if
+            call lo_get_phonon_dos_gaussian(pd, qp, dr, mw, verbosity)
+        case (2)
+            if (verbosity .gt. 0) then
+                write (*, "(1X,A)") '... adaptive gaussian integration, scalingfactor = '//tochar(pd%smearing_prefactor)//', N energy points: '//tochar(pd%n_dos_point)
+            end if
+            call lo_get_phonon_dos_gaussian(pd, qp, dr, mw, verbosity)
+        case (3)
+            if (verbosity .gt. 0) then
+                write (*, "(1X,A)") '... tetrahedron integration, N energy points: '//tochar(pd%n_dos_point)
+            end if
+            call lo_get_phonon_dos_tetrahedron(pd, qp, dr, mw, mem, verbosity)
+        case default
+            write (*, *) 'unknown integration type'
+            stop
         end select
     end block integrate
 
     ! Now fix the DOS so that it looks nice.
     makenice: block
-        integer :: i,j,k
-        real(r8), dimension(:,:), allocatable :: sitebuf
-        real(r8) :: f0,f1,dostol
+        integer :: i, j, k
+        real(r8), dimension(:, :), allocatable :: sitebuf
+        real(r8) :: f0, f1, dostol
 
         ! I might have gotten a contribution at zero frequency due to the smearing. That has to
         ! be removed. I subtract the line that goes from the dos at 0 to the max frequency.
-        do j=1,pd%n_mode
-            f1=pd%pdos_mode(1,j)
-            do i=1,pd%n_dos_point
-                f0=(pd%n_dos_point-i)*1.0_r8/( (pd%n_dos_point-1)*1.0_r8 )
-                f0=f0**2
-                pd%pdos_mode(i,j)=pd%pdos_mode(i,j)-f0*f1
-                if ( pd%pdos_mode(i,j) .lt. lo_freqtol ) pd%pdos_mode(i,j)=0.0_r8
-            enddo
-            pd%pdos_mode(1,j)=0.0_r8
-        enddo
-        do j=1,pd%n_atom
-            f1=pd%pdos_site(1,j)
-            do i=1,pd%n_dos_point
-                f0=(pd%n_dos_point-i)*1.0_r8/( (pd%n_dos_point-1)*1.0_r8 )
-                f0=f0**2
-                pd%pdos_site(i,j)=pd%pdos_site(i,j)-f0*f1
-                if ( pd%pdos_site(i,j) .lt. lo_freqtol ) pd%pdos_site(i,j)=0.0_r8
-            enddo
-            pd%pdos_site(1,j)=0.0_r8
-        enddo
+        do j = 1, pd%n_mode
+            f1 = pd%pdos_mode(1, j)
+            do i = 1, pd%n_dos_point
+                f0 = (pd%n_dos_point - i)*1.0_r8/((pd%n_dos_point - 1)*1.0_r8)
+                f0 = f0**2
+                pd%pdos_mode(i, j) = pd%pdos_mode(i, j) - f0*f1
+                if (pd%pdos_mode(i, j) .lt. lo_freqtol) pd%pdos_mode(i, j) = 0.0_r8
+            end do
+            pd%pdos_mode(1, j) = 0.0_r8
+        end do
+        do j = 1, pd%n_atom
+            f1 = pd%pdos_site(1, j)
+            do i = 1, pd%n_dos_point
+                f0 = (pd%n_dos_point - i)*1.0_r8/((pd%n_dos_point - 1)*1.0_r8)
+                f0 = f0**2
+                pd%pdos_site(i, j) = pd%pdos_site(i, j) - f0*f1
+                if (pd%pdos_site(i, j) .lt. lo_freqtol) pd%pdos_site(i, j) = 0.0_r8
+            end do
+            pd%pdos_site(1, j) = 0.0_r8
+        end do
 
         ! Sum up contributions and normalize things
-        pd%dos=0.0_r8
-        do j=1,pd%n_mode
-            f0=1.0_r8/lo_trapezoid_integration(pd%omega,pd%pdos_mode(:,j))
-            pd%dos=pd%dos+pd%pdos_mode(:,j)
-            pd%pdos_mode(:,j)=pd%pdos_mode(:,j)*f0
-        enddo
-        pd%dos(1)=0.0_r8
+        pd%dos = 0.0_r8
+        do j = 1, pd%n_mode
+            f0 = 1.0_r8/lo_trapezoid_integration(pd%omega, pd%pdos_mode(:, j))
+            pd%dos = pd%dos + pd%pdos_mode(:, j)
+            pd%pdos_mode(:, j) = pd%pdos_mode(:, j)*f0
+        end do
+        pd%dos(1) = 0.0_r8
         ! Get a tolerance where to slice off the phonon dos.
-        dostol=lo_mean(pd%dos)*lo_sqtol
-        pd%dos=lo_chop(pd%dos,dostol)
+        dostol = lo_mean(pd%dos)*lo_sqtol
+        pd%dos = lo_chop(pd%dos, dostol)
         ! Normalize the total
-        f0=lo_trapezoid_integration(pd%omega,pd%dos)
-        if ( verbosity .gt. 0 ) write(*,*) '... raw normalization (should be 1):',f0/dr%n_mode
-        pd%dos=pd%dos*dr%n_mode/f0
+        f0 = lo_trapezoid_integration(pd%omega, pd%dos)
+        if (verbosity .gt. 0) write (*, *) '... raw normalization (should be 1):', f0/dr%n_mode
+        pd%dos = pd%dos*dr%n_mode/f0
         ! Adjust the mode projected so that they sum up to the total
-        do i=1,pd%n_dos_point
-            f0=sum(pd%pdos_mode(i,:))
-            if ( f0 .gt. dostol ) then
-                pd%pdos_mode(i,:)=pd%pdos_mode(i,:)*pd%dos(i)/f0
+        do i = 1, pd%n_dos_point
+            f0 = sum(pd%pdos_mode(i, :))
+            if (f0 .gt. dostol) then
+                pd%pdos_mode(i, :) = pd%pdos_mode(i, :)*pd%dos(i)/f0
             else
-                pd%pdos_mode(i,:)=0.0_r8
-            endif
-        enddo
+                pd%pdos_mode(i, :) = 0.0_r8
+            end if
+        end do
 
         ! Fix the degeneracy of the site-projected
-        call mem%allocate(sitebuf,[pd%n_dos_point,pd%n_atom],persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
-        sitebuf=0.0_r8
-        do i=1,pd%n_atom
+        call mem%allocate(sitebuf, [pd%n_dos_point, pd%n_atom], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        sitebuf = 0.0_r8
+        do i = 1, pd%n_atom
             ! enfore site degeneracy
-            do j=1,uc%sym%degeneracy(i)
-                k=uc%sym%degenerate_atom(j,i)
-                sitebuf(:,i)=sitebuf(:,i)+pd%pdos_site(:,k)/(1.0_r8*uc%sym%degeneracy(j))
-            enddo
-            f0=lo_trapezoid_integration(pd%omega,sitebuf(:,i))
-            sitebuf(:,i)=sitebuf(:,i)*3.0_r8/f0
-        enddo
-        pd%pdos_site=sitebuf
-        call mem%deallocate(sitebuf,persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
+            do j = 1, uc%sym%degeneracy(i)
+                k = uc%sym%degenerate_atom(j, i)
+                sitebuf(:, i) = sitebuf(:, i) + pd%pdos_site(:, k)/(1.0_r8*uc%sym%degeneracy(j))
+            end do
+            f0 = lo_trapezoid_integration(pd%omega, sitebuf(:, i))
+            sitebuf(:, i) = sitebuf(:, i)*3.0_r8/f0
+        end do
+        pd%pdos_site = sitebuf
+        call mem%deallocate(sitebuf, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
         ! normalize the projections so that they add up to the total
-        do i=1,pd%n_dos_point
-            f0=sum(pd%pdos_site(i,:))
-            if ( f0 .gt. dostol ) then
-                pd%pdos_site(i,:)=pd%pdos_site(i,:)*pd%dos(i)/f0
+        do i = 1, pd%n_dos_point
+            f0 = sum(pd%pdos_site(i, :))
+            if (f0 .gt. dostol) then
+                pd%pdos_site(i, :) = pd%pdos_site(i, :)*pd%dos(i)/f0
             else
-                pd%pdos_site(i,:)=0.0_r8
-            endif
-        enddo
+                pd%pdos_site(i, :) = 0.0_r8
+            end if
+        end do
     end block makenice
 
-    if ( verbosity .gt. 0 ) then
-        write(*,*) 'Finished calculating the phonon density of states (',tochar(walltime()-timer),'s)'
-    endif
+    if (verbosity .gt. 0) then
+        write (*, *) 'Finished calculating the phonon density of states (', tochar(walltime() - timer), 's)'
+    end if
 end subroutine
 
 !> Print the phonon dos to hdf5
-subroutine write_to_hdf5(pd,p,enhet,filename,mem,hdftag)
+subroutine write_to_hdf5(pd, p, enhet, filename, mem, hdftag)
     !> phonon dos
     class(lo_phonon_dos), intent(in) :: pd
     !> crystal structure
@@ -312,72 +312,72 @@ subroutine write_to_hdf5(pd,p,enhet,filename,mem,hdftag)
     integer(i8), intent(in), optional :: hdftag
 
     type(lo_hdf5_helper) :: h5
-    real(r8), dimension(:,:), allocatable :: buf
+    real(r8), dimension(:, :), allocatable :: buf
     real(r8) :: unitfactor
-    character(len=100) :: omstr,dosstr
+    character(len=100) :: omstr, dosstr
     character(len=2000) :: atomnames
-    integer :: a1,a2,i
+    integer :: a1, a2, i
 
     ! The unit thingy
-    select case(enhet)
-        case('thz')
-            unitfactor=lo_frequency_hartree_to_THz
-            omstr='THz'
-            dosstr='States/THz'
-        case('mev')
-            unitfactor=lo_frequency_hartree_to_meV
-            omstr='meV'
-            dosstr='States/meV'
-        case('icm')
-            unitfactor=lo_frequency_hartree_to_icm
-            omstr='cm^-1'
-            dosstr='States/cm^-1'
-        case default
-            call lo_stop_gracefully(['Unknown unit'],lo_exitcode_param,__FILE__,__LINE__)
+    select case (enhet)
+    case ('thz')
+        unitfactor = lo_frequency_hartree_to_THz
+        omstr = 'THz'
+        dosstr = 'States/THz'
+    case ('mev')
+        unitfactor = lo_frequency_hartree_to_meV
+        omstr = 'meV'
+        dosstr = 'States/meV'
+    case ('icm')
+        unitfactor = lo_frequency_hartree_to_icm
+        omstr = 'cm^-1'
+        dosstr = 'States/cm^-1'
+    case default
+        call lo_stop_gracefully(['Unknown unit'], lo_exitcode_param, __FILE__, __LINE__)
     end select
 
     ! create the file, or use a provided tag
-    if ( present(hdftag) ) then
+    if (present(hdftag)) then
         ! Write to the tag that was provided
-        h5%file_id=hdftag
+        h5%file_id = hdftag
     else
         ! Create a new file.
-        call h5%init(__FILE__,__LINE__)
-        call h5%open_file('write',trim(filename))
-    endif
+        call h5%init(__FILE__, __LINE__)
+        call h5%open_file('write', trim(filename))
+    end if
 
     ! store all the data
-    call h5%store_data(pd%omega*unitfactor    ,h5%file_id,'frequencies',enhet=trim(omstr),dimensions='frequency')
-    call h5%store_data(pd%dos/unitfactor      ,h5%file_id,'dos',enhet=trim(dosstr),dimensions='dos')
-    call h5%store_data(pd%pdos_site/unitfactor,h5%file_id,'dos_per_site',enhet=trim(dosstr),dimensions='site,dos')
-    call h5%store_data(pd%pdos_mode/unitfactor,h5%file_id,'dos_per_mode',enhet=trim(dosstr),dimensions='mode,dos')
+    call h5%store_data(pd%omega*unitfactor, h5%file_id, 'frequencies', enhet=trim(omstr), dimensions='frequency')
+    call h5%store_data(pd%dos/unitfactor, h5%file_id, 'dos', enhet=trim(dosstr), dimensions='dos')
+    call h5%store_data(pd%pdos_site/unitfactor, h5%file_id, 'dos_per_site', enhet=trim(dosstr), dimensions='site,dos')
+    call h5%store_data(pd%pdos_mode/unitfactor, h5%file_id, 'dos_per_mode', enhet=trim(dosstr), dimensions='mode,dos')
 
     ! And store the atom labels
     call p%unique_atom_label(atomnames)
-    call h5%store_attribute(trim(adjustl(atomnames)),h5%file_id,'unique_atom_labels')
+    call h5%store_attribute(trim(adjustl(atomnames)), h5%file_id, 'unique_atom_labels')
 
     ! Store the density of states per unique atom
-    call mem%allocate(buf,[pd%n_dos_point,p%sym%n_irreducible_atom],persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
-    buf=0.0_r8
-    do a1=1,p%sym%n_irreducible_atom
-        do i=1,p%sym%irr_unfold_ctr(a1)
-            a2=p%sym%irr_unfold_index(i,a1)
-            buf(:,a1)=buf(:,a1)+pd%pdos_site(:,a2)
-        enddo
-    enddo
-    buf=buf/unitfactor
-    call h5%store_data(buf,h5%file_id,'dos_per_unique_atom',enhet=trim(dosstr),dimensions='unique atom,dos')
-    call mem%deallocate(buf,persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
+    call mem%allocate(buf, [pd%n_dos_point, p%sym%n_irreducible_atom], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    buf = 0.0_r8
+    do a1 = 1, p%sym%n_irreducible_atom
+        do i = 1, p%sym%irr_unfold_ctr(a1)
+            a2 = p%sym%irr_unfold_index(i, a1)
+            buf(:, a1) = buf(:, a1) + pd%pdos_site(:, a2)
+        end do
+    end do
+    buf = buf/unitfactor
+    call h5%store_data(buf, h5%file_id, 'dos_per_unique_atom', enhet=trim(dosstr), dimensions='unique atom,dos')
+    call mem%deallocate(buf, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
 
     ! close the file and hdf5, if relevant.
-    if ( present(hdftag) .eqv. .false. ) then
+    if (present(hdftag) .eqv. .false.) then
         call h5%close_file()
-        call h5%destroy(__FILE__,__LINE__)
-    endif
+        call h5%destroy(__FILE__, __LINE__)
+    end if
 end subroutine
 
 !> Writes phonon dos to file
-subroutine write_to_file(pd,uc,enhet,filename)
+subroutine write_to_file(pd, uc, enhet, filename)
     !> The phonon dos
     class(lo_phonon_dos), intent(in) :: pd
     !> The crystal structure
@@ -387,109 +387,109 @@ subroutine write_to_file(pd,uc,enhet,filename)
     !> optionally a different filename
     character(len=*), intent(in) :: filename
     !
-    integer :: i,j,u
+    integer :: i, j, u
     real(r8), dimension(:), allocatable :: y
     real(r8) :: unitfactor
-    character(len=100) :: opf,lgd
+    character(len=100) :: opf, lgd
 
     ! Figure out the output format
-    i=2+size(pd%pdos_site,2)+size(pd%pdos_mode,2)
-    opf="("//tochar(i)//"(1X,E18.12))"
-    allocate(y(i))
-    y=0.0_r8
+    i = 2 + size(pd%pdos_site, 2) + size(pd%pdos_mode, 2)
+    opf = "("//tochar(i)//"(1X,E18.12))"
+    allocate (y(i))
+    y = 0.0_r8
 
     ! The unit thingy
-    select case(enhet)
-        case('thz')
-            unitfactor=lo_frequency_hartree_to_THz
-        case('mev')
-            unitfactor=lo_frequency_hartree_to_meV
-        case('icm')
-            unitfactor=lo_frequency_hartree_to_icm
-        case default
-            call lo_stop_gracefully(['Unknown unit'],lo_exitcode_param,__FILE__,__LINE__)
+    select case (enhet)
+    case ('thz')
+        unitfactor = lo_frequency_hartree_to_THz
+    case ('mev')
+        unitfactor = lo_frequency_hartree_to_meV
+    case ('icm')
+        unitfactor = lo_frequency_hartree_to_icm
+    case default
+        call lo_stop_gracefully(['Unknown unit'], lo_exitcode_param, __FILE__, __LINE__)
     end select
 
     ! Print the raw data
-    u=open_file('out',trim(filename))
-        do i=1,pd%n_dos_point
-            y(1)=pd%omega(i)*unitfactor
-            y(2)=pd%dos(i)/unitfactor
-            do j=1,size(pd%pdos_site,2)
-                y(2+j)=pd%pdos_site(i,j)/unitfactor
-            enddo
-            do j=1,size(pd%pdos_mode,2)
-                y(2+size(pd%pdos_site,2)+j)=pd%pdos_mode(i,j)/unitfactor
-            enddo
-            write(u,opf) y
-        enddo
-    close(u)
-    deallocate(y)
+    u = open_file('out', trim(filename))
+    do i = 1, pd%n_dos_point
+        y(1) = pd%omega(i)*unitfactor
+        y(2) = pd%dos(i)/unitfactor
+        do j = 1, size(pd%pdos_site, 2)
+            y(2 + j) = pd%pdos_site(i, j)/unitfactor
+        end do
+        do j = 1, size(pd%pdos_mode, 2)
+            y(2 + size(pd%pdos_site, 2) + j) = pd%pdos_mode(i, j)/unitfactor
+        end do
+        write (u, opf) y
+    end do
+    close (u)
+    deallocate (y)
 
     ! Get the gnuplot file
-    u=open_file('out',trim(filename)//'.gnuplot')
-        ! Choose terminal
-        write(u,*) 'set terminal '//lo_gnuplotterminal//' size 800,400 enhanced font "CMU Serif,8"'
-        write(u,*) 'set multiplot'
-        write(u,*) 'set origin 0.0, 0.0'
-        write(u,*) 'set size 0.5, 1.0'
-        write(u,*) 'set border lw 0.5'
-        write(u,*) 'set ytics scale 0.5'
-        write(u,*) 'set xtics scale 0.5'
-        write(u,*) 'set mytics 10'
-        write(u,*) 'set mxtics 10'
-        select case(enhet)
-            case('thz')
-                write(u,*) ' set xlabel "Frequency (THz)" '
-            case('mev')
-                write(u,*) ' set xlabel "Frequency (meV)" '
-            case('icm')
-                write(u,*) ' set xlabel "Frequency (cm^-^1)" '
-        end select
-        write(u,*) ' set ylabel "DOS" '
-        write(u,*) ' set title "Site-projected DOS" '
-        write(u,*) 'set key top left'
-        write(u,'(A)',advance='no') 'plot'
-        write(u,'(A)') ' "'//trim(filename)//'" u 1:2 w line lc rgb "#318712" t "Total", \'
-        do i=1,pd%n_atom
-            lgd='site '//tochar(i)//', '//uc%atomic_symbol(uc%species(i))
-            write(u,'(A)',advance='no') ' "'//trim(filename)//'" u 1:'//tochar(i+2)//' w line'
-            write(u,'(A)',advance='no') ' t "'//trim(lgd)//'"'
-            if( i .lt. pd%n_atom ) then
-                write(u,'(A)') ',\'
-            endif
-        enddo
-        write(u,*) ' '
-        write(u,*) 'set origin 0.5, 0.0'
-        write(u,*) 'set size 0.5, 1.0'
-        write(u,*) 'set border lw 0.5'
-        write(u,*) 'set ytics scale 0.5'
-        write(u,*) 'set xtics scale 0.5'
-        write(u,*) 'set mytics 10'
-        write(u,*) 'set mxtics 10'
-        select case(enhet)
-            case('thz')
-                write(u,*) ' set xlabel "Frequency (THz)" '
-            case('mev')
-                write(u,*) ' set xlabel "Frequency (meV)" '
-            case('icm')
-                write(u,*) ' set xlabel "Frequency (cm^-^1)" '
-        end select
-        write(u,*) ' set ylabel "DOS" '
-        write(u,*) ' set title "Mode-projected DOS" '
-        write(u,*) 'set key top left'
-        write(u,'(A)',advance='no') 'plot'
-        write(u,'(A)') ' "'//trim(filename)//'" u 1:2 w line lc rgb "#318712" t "Total", \'
-        do i=1,size(pd%pdos_mode,2)
-            write(u,'(A)',advance='no') ' "'//trim(filename)//'" u 1:'//tochar(i+2+size(pd%pdos_site,2))//' w line'
-            write(u,'(A)',advance='no') ' t ""'
-            if( i .lt. size(pd%pdos_mode,2) ) then
-                write(u,'(A)') ',\'
-            endif
-        enddo
-        write(u,*) ' '
-        call lo_dump_palette_to_gnuplot(u)
-    close(u)
+    u = open_file('out', trim(filename)//'.gnuplot')
+    ! Choose terminal
+    write (u, *) 'set terminal '//lo_gnuplotterminal//' size 800,400 enhanced font "CMU Serif,8"'
+    write (u, *) 'set multiplot'
+    write (u, *) 'set origin 0.0, 0.0'
+    write (u, *) 'set size 0.5, 1.0'
+    write (u, *) 'set border lw 0.5'
+    write (u, *) 'set ytics scale 0.5'
+    write (u, *) 'set xtics scale 0.5'
+    write (u, *) 'set mytics 10'
+    write (u, *) 'set mxtics 10'
+    select case (enhet)
+    case ('thz')
+        write (u, *) ' set xlabel "Frequency (THz)" '
+    case ('mev')
+        write (u, *) ' set xlabel "Frequency (meV)" '
+    case ('icm')
+        write (u, *) ' set xlabel "Frequency (cm^-^1)" '
+    end select
+    write (u, *) ' set ylabel "DOS" '
+    write (u, *) ' set title "Site-projected DOS" '
+    write (u, *) 'set key top left'
+    write (u, '(A)', advance='no') 'plot'
+    write (u, '(A)') ' "'//trim(filename)//'" u 1:2 w line lc rgb "#318712" t "Total", \'
+    do i = 1, pd%n_atom
+        lgd = 'site '//tochar(i)//', '//uc%atomic_symbol(uc%species(i))
+        write (u, '(A)', advance='no') ' "'//trim(filename)//'" u 1:'//tochar(i + 2)//' w line'
+        write (u, '(A)', advance='no') ' t "'//trim(lgd)//'"'
+        if (i .lt. pd%n_atom) then
+            write (u, '(A)') ',\'
+        end if
+    end do
+    write (u, *) ' '
+    write (u, *) 'set origin 0.5, 0.0'
+    write (u, *) 'set size 0.5, 1.0'
+    write (u, *) 'set border lw 0.5'
+    write (u, *) 'set ytics scale 0.5'
+    write (u, *) 'set xtics scale 0.5'
+    write (u, *) 'set mytics 10'
+    write (u, *) 'set mxtics 10'
+    select case (enhet)
+    case ('thz')
+        write (u, *) ' set xlabel "Frequency (THz)" '
+    case ('mev')
+        write (u, *) ' set xlabel "Frequency (meV)" '
+    case ('icm')
+        write (u, *) ' set xlabel "Frequency (cm^-^1)" '
+    end select
+    write (u, *) ' set ylabel "DOS" '
+    write (u, *) ' set title "Mode-projected DOS" '
+    write (u, *) 'set key top left'
+    write (u, '(A)', advance='no') 'plot'
+    write (u, '(A)') ' "'//trim(filename)//'" u 1:2 w line lc rgb "#318712" t "Total", \'
+    do i = 1, size(pd%pdos_mode, 2)
+        write (u, '(A)', advance='no') ' "'//trim(filename)//'" u 1:'//tochar(i + 2 + size(pd%pdos_site, 2))//' w line'
+        write (u, '(A)', advance='no') ' t ""'
+        if (i .lt. size(pd%pdos_mode, 2)) then
+            write (u, '(A)') ',\'
+        end if
+    end do
+    write (u, *) ' '
+    call lo_dump_palette_to_gnuplot(u)
+    close (u)
 end subroutine
 
 !> measure size in memory, in bytes
@@ -499,13 +499,13 @@ function phonon_dos_size_in_mem(d) result(mem)
     !> memory in bytes
     integer :: mem
 
-    mem=0
-    mem=mem+storage_size(d)
-    if ( allocated(d%omega)     ) mem=mem+storage_size(d%omega)*size(d%omega)
-    if ( allocated(d%dos)       ) mem=mem+storage_size(d%dos)*size(d%dos)
-    if ( allocated(d%pdos_site) ) mem=mem+storage_size(d%pdos_site)*size(d%pdos_site)
-    if ( allocated(d%pdos_mode) ) mem=mem+storage_size(d%pdos_mode)*size(d%pdos_mode)
-    mem=mem/8
+    mem = 0
+    mem = mem + storage_size(d)
+    if (allocated(d%omega)) mem = mem + storage_size(d%omega)*size(d%omega)
+    if (allocated(d%dos)) mem = mem + storage_size(d%dos)*size(d%dos)
+    if (allocated(d%pdos_site)) mem = mem + storage_size(d%pdos_site)*size(d%pdos_site)
+    if (allocated(d%pdos_mode)) mem = mem + storage_size(d%pdos_mode)*size(d%pdos_mode)
+    mem = mem/8
 end function
 
 !> destroy everything
@@ -513,17 +513,17 @@ subroutine destroy(pd)
     !> phonon dos
     class(lo_phonon_dos), intent(inout) :: pd
 
-    if ( allocated(pd%omega)     ) deallocate(pd%omega)
-    if ( allocated(pd%dos)       ) deallocate(pd%dos)
-    if ( allocated(pd%pdos_site) ) deallocate(pd%pdos_site)
-    if ( allocated(pd%pdos_mode) ) deallocate(pd%pdos_mode)
-    pd%n_dos_point=-lo_hugeint
-    pd%n_atom=-lo_hugeint
-    pd%n_mode=-lo_hugeint
-    pd%dosmax=-lo_huge
-    pd%dosmin=-lo_huge
-    pd%integrationtype=-lo_hugeint
-    pd%smearing_prefactor=-lo_huge
+    if (allocated(pd%omega)) deallocate (pd%omega)
+    if (allocated(pd%dos)) deallocate (pd%dos)
+    if (allocated(pd%pdos_site)) deallocate (pd%pdos_site)
+    if (allocated(pd%pdos_mode)) deallocate (pd%pdos_mode)
+    pd%n_dos_point = -lo_hugeint
+    pd%n_atom = -lo_hugeint
+    pd%n_mode = -lo_hugeint
+    pd%dosmax = -lo_huge
+    pd%dosmin = -lo_huge
+    pd%integrationtype = -lo_hugeint
+    pd%smearing_prefactor = -lo_huge
 end subroutine
 
 end module

--- a/src/libolle/type_phonon_dos_integrations.f90
+++ b/src/libolle/type_phonon_dos_integrations.f90
@@ -1,11 +1,11 @@
-submodule (type_phonon_dos) type_phonon_dos_integrations
-use konstanter, only: lo_kappa_SI_to_au,lo_imag
-use gottochblandat, only: lo_harmonic_oscillator_cv,lo_outerproduct
+submodule(type_phonon_dos) type_phonon_dos_integrations
+use konstanter, only: lo_kappa_SI_to_au, lo_imag
+use gottochblandat, only: lo_harmonic_oscillator_cv, lo_outerproduct
 implicit none
 contains
 
 !> Get the spectral phonon angular momentum.
-module subroutine spectral_angular_momentum(pd,uc,qp,dr,temperature,mw,mem,spec_angmom,spec_angmom_band,spec_angmom_atom)
+module subroutine spectral_angular_momentum(pd, uc, qp, dr, temperature, mw, mem, spec_angmom, spec_angmom_band, spec_angmom_atom)
     !> phonon dos
     class(lo_phonon_dos), intent(inout) :: pd
     !> structure
@@ -21,411 +21,411 @@ module subroutine spectral_angular_momentum(pd,uc,qp,dr,temperature,mw,mem,spec_
     !> memory tracker
     type(lo_mem_helper), intent(inout) :: mem
     !> spectral
-    real(r8), dimension(:,:), allocatable, intent(out) :: spec_angmom
+    real(r8), dimension(:, :), allocatable, intent(out) :: spec_angmom
     !> spectral per band
-    real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_angmom_band
+    real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_angmom_band
     !> spectral per atom
-    real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_angmom_atom
+    real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_angmom_atom
 
-    real(r8), parameter :: angmomtol=1E-30_r8
-    real(r8), dimension(:,:,:), allocatable :: angmom_flat
+    real(r8), parameter :: angmomtol = 1E-30_r8
+    real(r8), dimension(:, :, :), allocatable :: angmom_flat
     real(r8), dimension(9) :: angmom_total
 
     call mem%tick()
     ! First I have to pre-calculate the angular momentum matrix thingy.
     init: block
-        complex(r8), dimension(3,3) :: Mx,My,Mz
-        complex(r8), dimension(3) :: cv0,cv1,cv2
-        real(r8), dimension(3) :: v0,v1,w0,w1
-        real(r8), dimension(3,3) :: m0
-        real(r8), dimension(:,:,:), allocatable :: kf
+        complex(r8), dimension(3, 3) :: Mx, My, Mz
+        complex(r8), dimension(3) :: cv0, cv1, cv2
+        real(r8), dimension(3) :: v0, v1, w0, w1
+        real(r8), dimension(3, 3) :: m0
+        real(r8), dimension(:, :, :), allocatable :: kf
         real(r8) :: f0
-        integer :: iq,ib,ii,i,k,o
+        integer :: iq, ib, ii, i, k, o
 
         ! Angular momentum representation:
-        Mx=0.0_r8
-        My=0.0_r8
-        Mz=0.0_r8
-        Mx(2,3)=1
-        Mx(3,2)=-1
-        My(1,3)=-1
-        My(3,1)=1
-        Mz(1,2)=1
-        Mz(2,1)=-1
-        Mx=-Mx*lo_imag
-        My=-My*lo_imag
-        Mz=-Mz*lo_imag
-        call mem%allocate(angmom_flat,[qp%n_full_point,dr%n_mode,9],persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
-        call mem%allocate(kf,[9,qp%n_irr_point,dr%n_mode],persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
-        angmom_flat=0.0_r8
-        kf=0.0_r8
-        do iq=1,qp%n_full_point
-            if ( mod(iq,mw%n) .ne. mw%r ) cycle
-            ii=qp%ap(iq)%irreducible_index
-            do ib=1,dr%n_mode
+        Mx = 0.0_r8
+        My = 0.0_r8
+        Mz = 0.0_r8
+        Mx(2, 3) = 1
+        Mx(3, 2) = -1
+        My(1, 3) = -1
+        My(3, 1) = 1
+        Mz(1, 2) = 1
+        Mz(2, 1) = -1
+        Mx = -Mx*lo_imag
+        My = -My*lo_imag
+        Mz = -Mz*lo_imag
+        call mem%allocate(angmom_flat, [qp%n_full_point, dr%n_mode, 9], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        call mem%allocate(kf, [9, qp%n_irr_point, dr%n_mode], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        angmom_flat = 0.0_r8
+        kf = 0.0_r8
+        do iq = 1, qp%n_full_point
+            if (mod(iq, mw%n) .ne. mw%r) cycle
+            ii = qp%ap(iq)%irreducible_index
+            do ib = 1, dr%n_mode
                 ! Skip acoustic
-                if ( dr%aq(iq)%omega(ib) .lt. lo_freqtol ) cycle
+                if (dr%aq(iq)%omega(ib) .lt. lo_freqtol) cycle
 
                 ! Calculate the angular momentum contribution from this mode
-                cv0=0.0_r8
-                do k=1,uc%na
-                    cv1=dr%aq(iq)%egv( (k-1)*3+1:k*3,ib )
-                    cv2=matmul(Mx,cv1)
-                    cv0(1)=cv0(1)+dot_product(cv1,cv2)
-                    cv2=matmul(My,cv1)
-                    cv0(2)=cv0(2)+dot_product(cv1,cv2)
-                    cv2=matmul(Mz,cv1)
-                    cv0(3)=cv0(3)+dot_product(cv1,cv2)
-                enddo
+                cv0 = 0.0_r8
+                do k = 1, uc%na
+                    cv1 = dr%aq(iq)%egv((k - 1)*3 + 1:k*3, ib)
+                    cv2 = matmul(Mx, cv1)
+                    cv0(1) = cv0(1) + dot_product(cv1, cv2)
+                    cv2 = matmul(My, cv1)
+                    cv0(2) = cv0(2) + dot_product(cv1, cv2)
+                    cv2 = matmul(Mz, cv1)
+                    cv0(3) = cv0(3) + dot_product(cv1, cv2)
+                end do
                 ! Now average over the small group. Seems sensible? Yes no maybe.
-                v0=0.0_r8
-                w0=0.0_r8
-                v1=real(cv0)
-                w1=dr%aq(iq)%vel(:,ib)
-                do k=1,qp%ap(iq)%n_invariant_operation
-                    o=qp%ap(iq)%invariant_operation(k)
-                    v0=v0+matmul(uc%sym%op(o)%m,v1)
-                    w0=w0+matmul(uc%sym%op(o)%m,w1)
-                enddo
-                v0=v0/real(qp%ap(iq)%n_invariant_operation,r8)
-                w0=w0/real(qp%ap(iq)%n_invariant_operation,r8)
+                v0 = 0.0_r8
+                w0 = 0.0_r8
+                v1 = real(cv0)
+                w1 = dr%aq(iq)%vel(:, ib)
+                do k = 1, qp%ap(iq)%n_invariant_operation
+                    o = qp%ap(iq)%invariant_operation(k)
+                    v0 = v0 + matmul(uc%sym%op(o)%m, v1)
+                    w0 = w0 + matmul(uc%sym%op(o)%m, w1)
+                end do
+                v0 = v0/real(qp%ap(iq)%n_invariant_operation, r8)
+                w0 = w0/real(qp%ap(iq)%n_invariant_operation, r8)
 
-                f0=lo_harmonic_oscillator_cv( temperature,dr%aq(iq)%omega(ib) )
-                f0=f0/dr%aq(iq)%omega(ib)
-                f0=f0*qp%ap(iq)%integration_weight
-                f0=f0*(2.0_r8*dr%iq(ii)%linewidth(ib))
-                v0=real(cv0,r8)*f0
-                m0=lo_outerproduct(v0,w0)
+                f0 = lo_harmonic_oscillator_cv(temperature, dr%aq(iq)%omega(ib))
+                f0 = f0/dr%aq(iq)%omega(ib)
+                f0 = f0*qp%ap(iq)%integration_weight
+                f0 = f0*(2.0_r8*dr%iq(ii)%linewidth(ib))
+                v0 = real(cv0, r8)*f0
+                m0 = lo_outerproduct(v0, w0)
 
-                kf(1,ii,ib)=kf(1,ii,ib)+m0(1,1)
-                kf(2,ii,ib)=kf(2,ii,ib)+m0(1,2)
-                kf(3,ii,ib)=kf(3,ii,ib)+m0(1,3)
-                kf(4,ii,ib)=kf(4,ii,ib)+m0(2,1)
-                kf(5,ii,ib)=kf(5,ii,ib)+m0(2,2)
-                kf(6,ii,ib)=kf(6,ii,ib)+m0(2,3)
-                kf(7,ii,ib)=kf(7,ii,ib)+m0(3,1)
-                kf(8,ii,ib)=kf(8,ii,ib)+m0(3,2)
-                kf(9,ii,ib)=kf(9,ii,ib)+m0(3,3)
-            enddo
-        enddo
-        call mw%allreduce('sum',kf)
+                kf(1, ii, ib) = kf(1, ii, ib) + m0(1, 1)
+                kf(2, ii, ib) = kf(2, ii, ib) + m0(1, 2)
+                kf(3, ii, ib) = kf(3, ii, ib) + m0(1, 3)
+                kf(4, ii, ib) = kf(4, ii, ib) + m0(2, 1)
+                kf(5, ii, ib) = kf(5, ii, ib) + m0(2, 2)
+                kf(6, ii, ib) = kf(6, ii, ib) + m0(2, 3)
+                kf(7, ii, ib) = kf(7, ii, ib) + m0(3, 1)
+                kf(8, ii, ib) = kf(8, ii, ib) + m0(3, 2)
+                kf(9, ii, ib) = kf(9, ii, ib) + m0(3, 3)
+            end do
+        end do
+        call mw%allreduce('sum', kf)
         ! Now rotate this out again
-        do iq=1,qp%n_full_point
-            ii=qp%ap(iq)%irreducible_index
-            f0=1.0_r8/qp%ip(ii)%integration_weight
-            do ib=1,dr%n_mode
-                angmom_flat(iq,ib,1)=kf(1,ii,ib)*f0
-                angmom_flat(iq,ib,2)=kf(2,ii,ib)*f0
-                angmom_flat(iq,ib,3)=kf(3,ii,ib)*f0
-                angmom_flat(iq,ib,4)=kf(4,ii,ib)*f0
-                angmom_flat(iq,ib,5)=kf(5,ii,ib)*f0
-                angmom_flat(iq,ib,6)=kf(6,ii,ib)*f0
-                angmom_flat(iq,ib,7)=kf(7,ii,ib)*f0
-                angmom_flat(iq,ib,8)=kf(8,ii,ib)*f0
-                angmom_flat(iq,ib,9)=kf(9,ii,ib)*f0
-            enddo
-        enddo
-        call mem%deallocate(kf,persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
+        do iq = 1, qp%n_full_point
+            ii = qp%ap(iq)%irreducible_index
+            f0 = 1.0_r8/qp%ip(ii)%integration_weight
+            do ib = 1, dr%n_mode
+                angmom_flat(iq, ib, 1) = kf(1, ii, ib)*f0
+                angmom_flat(iq, ib, 2) = kf(2, ii, ib)*f0
+                angmom_flat(iq, ib, 3) = kf(3, ii, ib)*f0
+                angmom_flat(iq, ib, 4) = kf(4, ii, ib)*f0
+                angmom_flat(iq, ib, 5) = kf(5, ii, ib)*f0
+                angmom_flat(iq, ib, 6) = kf(6, ii, ib)*f0
+                angmom_flat(iq, ib, 7) = kf(7, ii, ib)*f0
+                angmom_flat(iq, ib, 8) = kf(8, ii, ib)*f0
+                angmom_flat(iq, ib, 9) = kf(9, ii, ib)*f0
+            end do
+        end do
+        call mem%deallocate(kf, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
         ! And grab the total angular momentum
-        do i=1,9
-            angmom_total(i)=sum(angmom_flat(:,:,i))/qp%n_full_point
-        enddo
+        do i = 1, 9
+            angmom_total(i) = sum(angmom_flat(:, :, i))/qp%n_full_point
+        end do
         ! Remove tiny numbers
-        f0=norm2(angmom_total)
-        angmom_total=lo_chop(angmom_total,f0*1E-9_r8)
+        f0 = norm2(angmom_total)
+        angmom_total = lo_chop(angmom_total, f0*1E-9_r8)
 
         ! Space for the spectral angular momentum
-        allocate(spec_angmom(pd%n_dos_point,9))
-        allocate(spec_angmom_band(pd%n_dos_point,dr%n_mode,9))
-        allocate(spec_angmom_atom(pd%n_dos_point,uc%na,9))
-        spec_angmom=0.0_r8
-        spec_angmom_band=0.0_r8
-        spec_angmom_atom=0.0_r8
+        allocate (spec_angmom(pd%n_dos_point, 9))
+        allocate (spec_angmom_band(pd%n_dos_point, dr%n_mode, 9))
+        allocate (spec_angmom_atom(pd%n_dos_point, uc%na, 9))
+        spec_angmom = 0.0_r8
+        spec_angmom_band = 0.0_r8
+        spec_angmom_atom = 0.0_r8
     end block init
 
-    select case(pd%integrationtype)
-    case(1:2) ! Gaussian-type integrations
-    gaussint: block
-        complex(r8), dimension(3) :: cv0
-        real(r8), dimension(:,:,:), allocatable :: qproj
-        real(r8), dimension(:,:), allocatable :: qvals,qangmom
-        real(r8) :: sigma,f0,f1,invf,foursigma,weight
-        integer :: iq,lq,mode,atom,xval,ii,jj,direction,nq
+    select case (pd%integrationtype)
+    case (1:2) ! Gaussian-type integrations
+        gaussint: block
+            complex(r8), dimension(3) :: cv0
+            real(r8), dimension(:, :, :), allocatable :: qproj
+            real(r8), dimension(:, :), allocatable :: qvals, qangmom
+            real(r8) :: sigma, f0, f1, invf, foursigma, weight
+            integer :: iq, lq, mode, atom, xval, ii, jj, direction, nq
 
-        nq=0
-        do iq=1,qp%n_irr_point
-            if ( mod(iq,mw%n) .ne. mw%r ) cycle
-            nq=nq+1
-        enddo
+            nq = 0
+            do iq = 1, qp%n_irr_point
+                if (mod(iq, mw%n) .ne. mw%r) cycle
+                nq = nq + 1
+            end do
 
-        if ( nq .gt. 0 ) then
-            call mem%allocate(qvals,[nq,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(qproj,[uc%na,nq,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(qangmom,[nq,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            qvals=0.0_r8
-            qproj=0.0_r8
-            qangmom=0.0_r8
-            lq=0
-            do iq=1,qp%n_irr_point
-                if ( mod(iq,mw%n) .ne. mw%r ) cycle
-                lq=lq+1
-                do mode=1,dr%n_mode
-                    qvals(lq,mode)=dr%iq(iq)%omega(mode)
-                    do atom=1,uc%na
-                        cv0=dr%iq(iq)%egv( (atom-1)*3+1:atom*3 , mode )
-                        qproj(atom,lq,mode)=abs(dot_product(conjg(cv0),cv0))
-                    enddo
-                enddo
-            enddo
-        endif
+            if (nq .gt. 0) then
+                call mem%allocate(qvals, [nq, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(qproj, [uc%na, nq, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(qangmom, [nq, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                qvals = 0.0_r8
+                qproj = 0.0_r8
+                qangmom = 0.0_r8
+                lq = 0
+                do iq = 1, qp%n_irr_point
+                    if (mod(iq, mw%n) .ne. mw%r) cycle
+                    lq = lq + 1
+                    do mode = 1, dr%n_mode
+                        qvals(lq, mode) = dr%iq(iq)%omega(mode)
+                        do atom = 1, uc%na
+                            cv0 = dr%iq(iq)%egv((atom - 1)*3 + 1:atom*3, mode)
+                            qproj(atom, lq, mode) = abs(dot_product(conjg(cv0), cv0))
+                        end do
+                    end do
+                end do
+            end if
 
-        ! Do an actual integration. Should be the same integration type as before.
-        directionloop: do direction=1,9
-            ! skip irrelevant directions
-            if ( abs(angmom_total(direction)) .lt. angmomtol ) cycle
-            ! Fetch angmom values
-            lq=0
-            do iq=1,qp%n_irr_point
-                if ( mod(iq,mw%n) .ne. mw%r ) cycle
-                lq=lq+1
-                ii=qp%ip(iq)%full_index
-                do mode=1,dr%n_mode
-                    qangmom(lq,mode)=angmom_flat(ii,mode,direction)
-                enddo
-            enddo
+            ! Do an actual integration. Should be the same integration type as before.
+            directionloop: do direction = 1, 9
+                ! skip irrelevant directions
+                if (abs(angmom_total(direction)) .lt. angmomtol) cycle
+                ! Fetch angmom values
+                lq = 0
+                do iq = 1, qp%n_irr_point
+                    if (mod(iq, mw%n) .ne. mw%r) cycle
+                    lq = lq + 1
+                    ii = qp%ip(iq)%full_index
+                    do mode = 1, dr%n_mode
+                        qangmom(lq, mode) = angmom_flat(ii, mode, direction)
+                    end do
+                end do
 
-            ! Do the actual integration
-            invf=(pd%n_dos_point/maxval(pd%omega))
-            lq=0
-            do iq=1,qp%n_irr_point
-                if ( mod(iq,mw%n) .ne. mw%r ) cycle
-                lq=lq+1
-                weight=qp%ip(iq)%integration_weight
-                do mode=1,dr%n_mode
-                    f1=qvals(lq,mode) ! frequency
-                    if ( f1 .lt. dr%omega_min*0.5_r8 ) cycle
+                ! Do the actual integration
+                invf = (pd%n_dos_point/maxval(pd%omega))
+                lq = 0
+                do iq = 1, qp%n_irr_point
+                    if (mod(iq, mw%n) .ne. mw%r) cycle
+                    lq = lq + 1
+                    weight = qp%ip(iq)%integration_weight
+                    do mode = 1, dr%n_mode
+                        f1 = qvals(lq, mode) ! frequency
+                        if (f1 .lt. dr%omega_min*0.5_r8) cycle
 
-                    ! Get the smearing parameter
-                    select case(pd%integrationtype)
-                        case(1) ! fix gaussian
-                            sigma=dr%default_smearing(mode)*pd%smearing_prefactor
-                        case(2) ! adaptive gaussian
-                            sigma=qp%smearingparameter(dr%iq(iq)%vel(:,mode),dr%default_smearing(mode),pd%smearing_prefactor)
-                    end select
-                    foursigma=sigma*4
+                        ! Get the smearing parameter
+                        select case (pd%integrationtype)
+                        case (1) ! fix gaussian
+                            sigma = dr%default_smearing(mode)*pd%smearing_prefactor
+                        case (2) ! adaptive gaussian
+                            sigma = qp%smearingparameter(dr%iq(iq)%vel(:, mode), dr%default_smearing(mode), pd%smearing_prefactor)
+                        end select
+                        foursigma = sigma*4
 
-                    ! range of integration
-                    ii=max( floor( (f1-foursigma)*invf ), 1)
-                    jj=min( floor( (f1+foursigma)*invf ), pd%n_dos_point)
-                    do xval=ii,jj
-                        f0=lo_gauss(f1,pd%omega(xval),sigma)*weight
-                        spec_angmom_band(xval,mode,direction)=spec_angmom_band(xval,mode,direction)+qangmom(lq,mode)*f0
-                        do atom=1,uc%na
-                            spec_angmom_atom(xval,atom,direction)=spec_angmom_atom(xval,atom,direction)+qangmom(lq,mode)*qproj(atom,lq,mode)*f0
-                        enddo
-                    enddo
-                enddo
-            enddo
-        enddo directionloop
-        ! Add together
-        call mw%allreduce('sum',spec_angmom_atom)
-        call mw%allreduce('sum',spec_angmom_band)
-        ! And cleanup
-        if ( nq .gt. 0 ) then
-            call mem%deallocate(qvals,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(qproj,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(qangmom,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-        endif
-    end block gaussint
-    case(3) ! Tetrahedron integration
-    tetint: block
-        complex(r8), dimension(3) :: cv0
-        real(r8), dimension(:,:,:,:), allocatable :: tetproj
-        real(r8), dimension(:,:,:), allocatable :: tetvals,tetangmom
-        real(r8), dimension(4) :: w,tete
-        real(r8) :: sigma,mine,maxe,invf
-        integer :: i,l,mode,atom,xval,ii,jj,direction
-        integer :: itet,ltet,ntet
+                        ! range of integration
+                        ii = max(floor((f1 - foursigma)*invf), 1)
+                        jj = min(floor((f1 + foursigma)*invf), pd%n_dos_point)
+                        do xval = ii, jj
+                            f0 = lo_gauss(f1, pd%omega(xval), sigma)*weight
+                            spec_angmom_band(xval, mode, direction) = spec_angmom_band(xval, mode, direction) + qangmom(lq, mode)*f0
+                            do atom = 1, uc%na
+                                spec_angmom_atom(xval, atom, direction) = spec_angmom_atom(xval, atom, direction) + qangmom(lq, mode)*qproj(atom, lq, mode)*f0
+                            end do
+                        end do
+                    end do
+                end do
+            end do directionloop
+            ! Add together
+            call mw%allreduce('sum', spec_angmom_atom)
+            call mw%allreduce('sum', spec_angmom_band)
+            ! And cleanup
+            if (nq .gt. 0) then
+                call mem%deallocate(qvals, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(qproj, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(qangmom, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+            end if
+        end block gaussint
+    case (3) ! Tetrahedron integration
+        tetint: block
+            complex(r8), dimension(3) :: cv0
+            real(r8), dimension(:, :, :, :), allocatable :: tetproj
+            real(r8), dimension(:, :, :), allocatable :: tetvals, tetangmom
+            real(r8), dimension(4) :: w, tete
+            real(r8) :: sigma, mine, maxe, invf
+            integer :: i, l, mode, atom, xval, ii, jj, direction
+            integer :: itet, ltet, ntet
 
-        ! Count tetrahedrons per rank
-        ntet=0
-        do itet=1,qp%n_irr_tet
-            if ( mod(itet,mw%n) .eq. mw%r ) ntet=ntet+1
-        enddo
+            ! Count tetrahedrons per rank
+            ntet = 0
+            do itet = 1, qp%n_irr_tet
+                if (mod(itet, mw%n) .eq. mw%r) ntet = ntet + 1
+            end do
 
-        ! Pre-fetch data
-        if ( ntet .gt. 0 ) then
-            call mem%allocate(tetvals,[4,ntet,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(tetangmom,[4,ntet,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(tetproj,[4,uc%na,ntet,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            tetvals=0.0_r8
-            tetangmom=0.0_r8
-            tetproj=0.0_r8
-            ltet=0
-            do itet=1,qp%n_irr_tet
-                if ( mod(itet,mw%n) .ne. mw%r ) cycle
-                ltet=ltet+1
-                do i=1,4
-                    l=qp%it(itet)%full_index(i)
-                    do mode=1,dr%n_mode
-                        tetvals(i,ltet,mode)=dr%aq(l)%omega(mode)
-                        do atom=1,uc%na
-                            cv0=dr%aq(l)%egv( (atom-1)*3+1:atom*3 , mode )
-                            tetproj(i,atom,ltet,mode)=abs(dot_product(conjg(cv0),cv0))
-                        enddo
-                    enddo
-                enddo
-            enddo
-        endif
+            ! Pre-fetch data
+            if (ntet .gt. 0) then
+                call mem%allocate(tetvals, [4, ntet, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(tetangmom, [4, ntet, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(tetproj, [4, uc%na, ntet, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                tetvals = 0.0_r8
+                tetangmom = 0.0_r8
+                tetproj = 0.0_r8
+                ltet = 0
+                do itet = 1, qp%n_irr_tet
+                    if (mod(itet, mw%n) .ne. mw%r) cycle
+                    ltet = ltet + 1
+                    do i = 1, 4
+                        l = qp%it(itet)%full_index(i)
+                        do mode = 1, dr%n_mode
+                            tetvals(i, ltet, mode) = dr%aq(l)%omega(mode)
+                            do atom = 1, uc%na
+                                cv0 = dr%aq(l)%egv((atom - 1)*3 + 1:atom*3, mode)
+                                tetproj(i, atom, ltet, mode) = abs(dot_product(conjg(cv0), cv0))
+                            end do
+                        end do
+                    end do
+                end do
+            end if
 
-        spec_angmom_atom=0.0_r8
-        spec_angmom_band=0.0_r8
-        directionloop: do direction=1,9
-            ! angmom values for this direction
-            tetangmom=0.0_r8
-            ltet=0
-            do itet=1,qp%n_irr_tet
-                if ( mod(itet,mw%n) .ne. mw%r ) cycle
-                ltet=ltet+1
-                do i=1,4
-                    l=qp%it(itet)%full_index(i)
-                    do mode=1,dr%n_mode
-                        tetangmom(i,ltet,mode)=angmom_flat(l,mode,direction)
-                    enddo
-                enddo
-            enddo
+            spec_angmom_atom = 0.0_r8
+            spec_angmom_band = 0.0_r8
+            directionloop: do direction = 1, 9
+                ! angmom values for this direction
+                tetangmom = 0.0_r8
+                ltet = 0
+                do itet = 1, qp%n_irr_tet
+                    if (mod(itet, mw%n) .ne. mw%r) cycle
+                    ltet = ltet + 1
+                    do i = 1, 4
+                        l = qp%it(itet)%full_index(i)
+                        do mode = 1, dr%n_mode
+                            tetangmom(i, ltet, mode) = angmom_flat(l, mode, direction)
+                        end do
+                    end do
+                end do
 
-            invf=(pd%n_dos_point/maxval(pd%omega))
-            do mode=1,dr%n_mode
-                sigma=dr%default_smearing(mode)
-                ltet=0
-                do itet=1,qp%n_irr_tet
-                    if ( mod(itet,mw%n) .ne. mw%r ) cycle
-                    ltet=ltet+1
-                    tete=tetvals(:,ltet,mode)
-                    mine=minval(tete)
-                    maxe=maxval(tete)
-                    ii=max(floor( mine*invf ),1)
-                    jj=min(ceiling( maxe*invf ),pd%n_dos_point)
-                    do xval=ii,jj
-                        w=lo_LV_tetrahedron_weights(tete,pd%omega(xval),lo_freqtol,sigma)*qp%it(itet)%integration_weight
-                        spec_angmom_band(xval,mode,direction)=spec_angmom_band(xval,mode,direction)+sum(w*tetangmom(:,ltet,mode))
-                        do atom=1,uc%na
-                            spec_angmom_atom(xval,atom,direction)=spec_angmom_atom(xval,atom,direction)+sum(w*tetangmom(:,ltet,mode)*tetproj(:,atom,ltet,mode))
-                        enddo
-                    enddo
-                enddo
-            enddo
-        enddo directionloop
-        call mw%allreduce('sum',spec_angmom_atom)
-        call mw%allreduce('sum',spec_angmom_band)
-        if ( ntet .gt. 0 ) then
-            call mem%deallocate(tetvals,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(tetangmom,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(tetproj,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-        endif
-    end block tetint
+                invf = (pd%n_dos_point/maxval(pd%omega))
+                do mode = 1, dr%n_mode
+                    sigma = dr%default_smearing(mode)
+                    ltet = 0
+                    do itet = 1, qp%n_irr_tet
+                        if (mod(itet, mw%n) .ne. mw%r) cycle
+                        ltet = ltet + 1
+                        tete = tetvals(:, ltet, mode)
+                        mine = minval(tete)
+                        maxe = maxval(tete)
+                        ii = max(floor(mine*invf), 1)
+                        jj = min(ceiling(maxe*invf), pd%n_dos_point)
+                        do xval = ii, jj
+                            w = lo_LV_tetrahedron_weights(tete, pd%omega(xval), lo_freqtol, sigma)*qp%it(itet)%integration_weight
+                            spec_angmom_band(xval, mode, direction) = spec_angmom_band(xval, mode, direction) + sum(w*tetangmom(:, ltet, mode))
+                            do atom = 1, uc%na
+                                spec_angmom_atom(xval, atom, direction) = spec_angmom_atom(xval, atom, direction) + sum(w*tetangmom(:, ltet, mode)*tetproj(:, atom, ltet, mode))
+                            end do
+                        end do
+                    end do
+                end do
+            end do directionloop
+            call mw%allreduce('sum', spec_angmom_atom)
+            call mw%allreduce('sum', spec_angmom_band)
+            if (ntet .gt. 0) then
+                call mem%deallocate(tetvals, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(tetangmom, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(tetproj, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+            end if
+        end block tetint
     case default
-        call lo_stop_gracefully(['Unknown integration type'],lo_exitcode_param,__FILE__,__LINE__,mw%comm)
+        call lo_stop_gracefully(['Unknown integration type'], lo_exitcode_param, __FILE__, __LINE__, mw%comm)
     end select
     ! Now we don't need the flat angular momentum anymore
-    call mem%deallocate(angmom_flat,persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
+    call mem%deallocate(angmom_flat, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
 
     ! Now make the spectrum look a little nicer.
     makenice: block
-        integer, parameter :: nkernel=6
+        integer, parameter :: nkernel = 6
         real(r8), dimension(-nkernel:nkernel) :: kernel
         real(r8), dimension(:), allocatable :: ysm
-        real(r8) :: f0,f1,f2
-        integer :: direction,i,j,k,atom,mode
+        real(r8) :: f0, f1, f2
+        integer :: direction, i, j, k, atom, mode
 
         ! Prepare the smearing kernel
-        do i=-nkernel,nkernel
-            kernel(i)=lo_gauss(0.0_r8,i*1.0_r8,1.5_r8)
-        enddo
-        kernel=kernel/sum(kernel)
-        allocate(ysm(-nkernel:pd%n_dos_point+nkernel))
-        ysm=0.0_r8
+        do i = -nkernel, nkernel
+            kernel(i) = lo_gauss(0.0_r8, i*1.0_r8, 1.5_r8)
+        end do
+        kernel = kernel/sum(kernel)
+        allocate (ysm(-nkernel:pd%n_dos_point + nkernel))
+        ysm = 0.0_r8
 
-        dirloop: do direction=1,9
-            if ( abs(angmom_total(direction)) .lt. angmomtol ) cycle
+        dirloop: do direction = 1, 9
+            if (abs(angmom_total(direction)) .lt. angmomtol) cycle
 
             ! Smear things slightly
-            do atom=1,uc%na
-                ysm=0.0_r8
-                do i=1,pd%n_dos_point
-                do j=-nkernel,nkernel
-                    ysm(i+j)=ysm(i+j)+kernel(j)*spec_angmom_atom(i,atom,direction)
-                enddo
-                enddo
-                spec_angmom_atom(:,atom,direction)=ysm(1:pd%n_dos_point)
-            enddo
-            do mode=1,dr%n_mode
-                ysm=0.0_r8
-                do i=1,pd%n_dos_point
-                do j=-nkernel,nkernel
-                    ysm(i+j)=ysm(i+j)+kernel(j)*spec_angmom_band(i,mode,direction)
-                enddo
-                enddo
-                spec_angmom_band(:,mode,direction)=ysm(1:pd%n_dos_point)
-            enddo
+            do atom = 1, uc%na
+                ysm = 0.0_r8
+                do i = 1, pd%n_dos_point
+                do j = -nkernel, nkernel
+                    ysm(i + j) = ysm(i + j) + kernel(j)*spec_angmom_atom(i, atom, direction)
+                end do
+                end do
+                spec_angmom_atom(:, atom, direction) = ysm(1:pd%n_dos_point)
+            end do
+            do mode = 1, dr%n_mode
+                ysm = 0.0_r8
+                do i = 1, pd%n_dos_point
+                do j = -nkernel, nkernel
+                    ysm(i + j) = ysm(i + j) + kernel(j)*spec_angmom_band(i, mode, direction)
+                end do
+                end do
+                spec_angmom_band(:, mode, direction) = ysm(1:pd%n_dos_point)
+            end do
 
             ! Fix site degeneracies
-            do i=1,uc%na
-                ysm=0.0_r8
-                do j=1,uc%sym%degeneracy(i)
-                    k=uc%sym%degenerate_atom(j,i)
-                    ysm(1:pd%n_dos_point)=ysm(1:pd%n_dos_point)+spec_angmom_atom(:,i,direction)/(1.0_r8*uc%sym%degeneracy(i))
-                enddo
-                do j=1,uc%sym%degeneracy(i)
-                    k=uc%sym%degenerate_atom(j,i)
-                    spec_angmom_atom(:,k,direction)=ysm(1:pd%n_dos_point)
-                enddo
-            enddo
+            do i = 1, uc%na
+                ysm = 0.0_r8
+                do j = 1, uc%sym%degeneracy(i)
+                    k = uc%sym%degenerate_atom(j, i)
+                    ysm(1:pd%n_dos_point) = ysm(1:pd%n_dos_point) + spec_angmom_atom(:, i, direction)/(1.0_r8*uc%sym%degeneracy(i))
+                end do
+                do j = 1, uc%sym%degeneracy(i)
+                    k = uc%sym%degenerate_atom(j, i)
+                    spec_angmom_atom(:, k, direction) = ysm(1:pd%n_dos_point)
+                end do
+            end do
 
             ! Add up to total, and normalize properly
-            spec_angmom(:,direction)=0.0_r8
-            do mode=1,dr%n_mode
-                spec_angmom(:,direction)=spec_angmom(:,direction)+spec_angmom_band(:,mode,direction)
-            enddo
-            f0=lo_trapezoid_integration(pd%omega,spec_angmom(:,direction))
-            if ( abs(f0) .gt. angmomtol ) then
-                spec_angmom(:,direction)=spec_angmom(:,direction)*angmom_total(direction)/f0
+            spec_angmom(:, direction) = 0.0_r8
+            do mode = 1, dr%n_mode
+                spec_angmom(:, direction) = spec_angmom(:, direction) + spec_angmom_band(:, mode, direction)
+            end do
+            f0 = lo_trapezoid_integration(pd%omega, spec_angmom(:, direction))
+            if (abs(f0) .gt. angmomtol) then
+                spec_angmom(:, direction) = spec_angmom(:, direction)*angmom_total(direction)/f0
             else
-                spec_angmom(:,direction)=0.0_r8
-            endif
+                spec_angmom(:, direction) = 0.0_r8
+            end if
 
             ! ! Make sure the projected add up to the total.
-            do i=1,pd%n_dos_point
-                f0=sum(spec_angmom_atom(i,:,direction))
-                f1=sum(spec_angmom_band(i,:,direction))
-                f2=spec_angmom(i,direction)
+            do i = 1, pd%n_dos_point
+                f0 = sum(spec_angmom_atom(i, :, direction))
+                f1 = sum(spec_angmom_band(i, :, direction))
+                f2 = spec_angmom(i, direction)
                 ! make sure there is finite angmom
-                if ( abs(f2) .gt. angmomtol ) then
-                    if ( abs(f0) .gt. angmomtol ) then
-                        spec_angmom_atom(i,:,direction)=spec_angmom_atom(i,:,direction)*f2/f0
+                if (abs(f2) .gt. angmomtol) then
+                    if (abs(f0) .gt. angmomtol) then
+                        spec_angmom_atom(i, :, direction) = spec_angmom_atom(i, :, direction)*f2/f0
                     else
-                        spec_angmom_atom(i,:,direction)=0.0_r8
-                    endif
-                    if ( abs(f1) .gt. angmomtol ) then
-                        spec_angmom_band(i,:,direction)=spec_angmom_band(i,:,direction)*f2/f1
+                        spec_angmom_atom(i, :, direction) = 0.0_r8
+                    end if
+                    if (abs(f1) .gt. angmomtol) then
+                        spec_angmom_band(i, :, direction) = spec_angmom_band(i, :, direction)*f2/f1
                     else
-                        spec_angmom_band(i,:,direction)=0.0_r8
-                    endif
+                        spec_angmom_band(i, :, direction) = 0.0_r8
+                    end if
                 else
-                    spec_angmom(i,direction)=0.0_r8
-                    spec_angmom_band(i,:,direction)=0.0_r8
-                    spec_angmom_atom(i,:,direction)=0.0_r8
-                endif
-            enddo
-        enddo dirloop
-        deallocate(ysm)
+                    spec_angmom(i, direction) = 0.0_r8
+                    spec_angmom_band(i, :, direction) = 0.0_r8
+                    spec_angmom_atom(i, :, direction) = 0.0_r8
+                end if
+            end do
+        end do dirloop
+        deallocate (ysm)
     end block makenice
-    call mem%tock(__FILE__,__LINE__,mw%comm)
+    call mem%tock(__FILE__, __LINE__, mw%comm)
 end subroutine
 
 !> Get the spectral thermal conductivity, very close to a DOS integration
-module subroutine spectral_kappa(pd,uc,qp,dr,mw,mem,spec_kappa,spec_kappa_band,spec_kappa_atom)
+module subroutine spectral_kappa(pd, uc, qp, dr, mw, mem, spec_kappa, spec_kappa_band, spec_kappa_atom)
     !> phonon dos
     class(lo_phonon_dos), intent(inout) :: pd
     !> structure
@@ -439,377 +439,377 @@ module subroutine spectral_kappa(pd,uc,qp,dr,mw,mem,spec_kappa,spec_kappa_band,s
     !> memory helper
     type(lo_mem_helper), intent(inout) :: mem
     !> spectral kappa
-    real(r8), dimension(:,:), allocatable, intent(out) :: spec_kappa
+    real(r8), dimension(:, :), allocatable, intent(out) :: spec_kappa
     !> spectral kappa per band
-    real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_kappa_band
+    real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_kappa_band
     !> spectral kappa per atom
-    real(r8), dimension(:,:,:), allocatable, intent(out) :: spec_kappa_atom
+    real(r8), dimension(:, :, :), allocatable, intent(out) :: spec_kappa_atom
 
-    real(r8), parameter :: kappatol=1E-6_r8*lo_kappa_SI_to_au
-    real(r8), dimension(:,:,:), allocatable :: kappa_flat
+    real(r8), parameter :: kappatol = 1E-6_r8*lo_kappa_SI_to_au
+    real(r8), dimension(:, :, :), allocatable :: kappa_flat
     real(r8), dimension(9) :: kappa_total
 
     call mem%tick()
     ! Pre-fetch some data
     init: block
-        real(r8), dimension(:,:,:), allocatable :: kf
+        real(r8), dimension(:, :, :), allocatable :: kf
         real(r8) :: f0
-        integer :: iq,ib,ii,i
+        integer :: iq, ib, ii, i
 
-        call mem%allocate(kappa_flat,[qp%n_full_point,dr%n_mode,9],persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
-        call mem%allocate(kf,[9,qp%n_irr_point,dr%n_mode],persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
-        kappa_flat=0.0_r8
-        kf=0.0_r8
-        do iq=1,qp%n_full_point
-            if ( mod(iq,mw%n) .ne. mw%r ) cycle
-            ii=qp%ap(iq)%irreducible_index
-            do ib=1,dr%n_mode
-                kf(1,ii,ib)=kf(1,ii,ib)+dr%aq(iq)%kappa(1,1,ib)
-                kf(2,ii,ib)=kf(2,ii,ib)+dr%aq(iq)%kappa(1,2,ib)
-                kf(3,ii,ib)=kf(3,ii,ib)+dr%aq(iq)%kappa(1,3,ib)
-                kf(4,ii,ib)=kf(4,ii,ib)+dr%aq(iq)%kappa(2,1,ib)
-                kf(5,ii,ib)=kf(5,ii,ib)+dr%aq(iq)%kappa(2,2,ib)
-                kf(6,ii,ib)=kf(6,ii,ib)+dr%aq(iq)%kappa(2,3,ib)
-                kf(7,ii,ib)=kf(7,ii,ib)+dr%aq(iq)%kappa(3,1,ib)
-                kf(8,ii,ib)=kf(8,ii,ib)+dr%aq(iq)%kappa(3,2,ib)
-                kf(9,ii,ib)=kf(9,ii,ib)+dr%aq(iq)%kappa(3,3,ib)
-            enddo
-        enddo
-        call mw%allreduce('sum',kf)
+        call mem%allocate(kappa_flat, [qp%n_full_point, dr%n_mode, 9], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        call mem%allocate(kf, [9, qp%n_irr_point, dr%n_mode], persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        kappa_flat = 0.0_r8
+        kf = 0.0_r8
+        do iq = 1, qp%n_full_point
+            if (mod(iq, mw%n) .ne. mw%r) cycle
+            ii = qp%ap(iq)%irreducible_index
+            do ib = 1, dr%n_mode
+                kf(1, ii, ib) = kf(1, ii, ib) + dr%aq(iq)%kappa(1, 1, ib)
+                kf(2, ii, ib) = kf(2, ii, ib) + dr%aq(iq)%kappa(1, 2, ib)
+                kf(3, ii, ib) = kf(3, ii, ib) + dr%aq(iq)%kappa(1, 3, ib)
+                kf(4, ii, ib) = kf(4, ii, ib) + dr%aq(iq)%kappa(2, 1, ib)
+                kf(5, ii, ib) = kf(5, ii, ib) + dr%aq(iq)%kappa(2, 2, ib)
+                kf(6, ii, ib) = kf(6, ii, ib) + dr%aq(iq)%kappa(2, 3, ib)
+                kf(7, ii, ib) = kf(7, ii, ib) + dr%aq(iq)%kappa(3, 1, ib)
+                kf(8, ii, ib) = kf(8, ii, ib) + dr%aq(iq)%kappa(3, 2, ib)
+                kf(9, ii, ib) = kf(9, ii, ib) + dr%aq(iq)%kappa(3, 3, ib)
+            end do
+        end do
+        call mw%allreduce('sum', kf)
         ! Now rotate this out again
-        do iq=1,qp%n_full_point
-            ii=qp%ap(iq)%irreducible_index
-            f0=1.0_r8/qp%ip(ii)%integration_weight
-            do ib=1,dr%n_mode
-                kappa_flat(iq,ib,1)=kf(1,ii,ib)*f0
-                kappa_flat(iq,ib,2)=kf(2,ii,ib)*f0
-                kappa_flat(iq,ib,3)=kf(3,ii,ib)*f0
-                kappa_flat(iq,ib,4)=kf(4,ii,ib)*f0
-                kappa_flat(iq,ib,5)=kf(5,ii,ib)*f0
-                kappa_flat(iq,ib,6)=kf(6,ii,ib)*f0
-                kappa_flat(iq,ib,7)=kf(7,ii,ib)*f0
-                kappa_flat(iq,ib,8)=kf(8,ii,ib)*f0
-                kappa_flat(iq,ib,9)=kf(9,ii,ib)*f0
-            enddo
-        enddo
-        call mem%deallocate(kf,persistent=.false.,scalable=.false.,file=__FILE__,line=__LINE__)
-        kappa_flat=lo_chop(kappa_flat/qp%n_full_point,kappatol)
+        do iq = 1, qp%n_full_point
+            ii = qp%ap(iq)%irreducible_index
+            f0 = 1.0_r8/qp%ip(ii)%integration_weight
+            do ib = 1, dr%n_mode
+                kappa_flat(iq, ib, 1) = kf(1, ii, ib)*f0
+                kappa_flat(iq, ib, 2) = kf(2, ii, ib)*f0
+                kappa_flat(iq, ib, 3) = kf(3, ii, ib)*f0
+                kappa_flat(iq, ib, 4) = kf(4, ii, ib)*f0
+                kappa_flat(iq, ib, 5) = kf(5, ii, ib)*f0
+                kappa_flat(iq, ib, 6) = kf(6, ii, ib)*f0
+                kappa_flat(iq, ib, 7) = kf(7, ii, ib)*f0
+                kappa_flat(iq, ib, 8) = kf(8, ii, ib)*f0
+                kappa_flat(iq, ib, 9) = kf(9, ii, ib)*f0
+            end do
+        end do
+        call mem%deallocate(kf, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        kappa_flat = lo_chop(kappa_flat/qp%n_full_point, kappatol)
         ! And grab the total Kappa
-        do i=1,9
-            kappa_total(i)=sum(kappa_flat(:,:,i))/qp%n_full_point
-        enddo
+        do i = 1, 9
+            kappa_total(i) = sum(kappa_flat(:, :, i))/qp%n_full_point
+        end do
 
         ! Space for the spectral kappa
-        allocate(spec_kappa(pd%n_dos_point,9))
-        allocate(spec_kappa_band(pd%n_dos_point,dr%n_mode,9))
-        allocate(spec_kappa_atom(pd%n_dos_point,uc%na,9))
-        spec_kappa=0.0_r8
-        spec_kappa_band=0.0_r8
-        spec_kappa_atom=0.0_r8
+        allocate (spec_kappa(pd%n_dos_point, 9))
+        allocate (spec_kappa_band(pd%n_dos_point, dr%n_mode, 9))
+        allocate (spec_kappa_atom(pd%n_dos_point, uc%na, 9))
+        spec_kappa = 0.0_r8
+        spec_kappa_band = 0.0_r8
+        spec_kappa_atom = 0.0_r8
     end block init
 
-    select case(pd%integrationtype)
-    case(1:2) ! Gaussian-type integrations
-    gaussint: block
-        complex(r8), dimension(3) :: cv0
-        real(r8), dimension(:,:,:), allocatable :: qproj
-        real(r8), dimension(:,:), allocatable :: qvals,qkappa
-        real(r8) :: sigma,f0,f1,invf,foursigma,weight
-        integer :: iq,lq,mode,atom,xval,ii,jj,direction,nq
+    select case (pd%integrationtype)
+    case (1:2) ! Gaussian-type integrations
+        gaussint: block
+            complex(r8), dimension(3) :: cv0
+            real(r8), dimension(:, :, :), allocatable :: qproj
+            real(r8), dimension(:, :), allocatable :: qvals, qkappa
+            real(r8) :: sigma, f0, f1, invf, foursigma, weight
+            integer :: iq, lq, mode, atom, xval, ii, jj, direction, nq
 
-        nq=0
-        do iq=1,qp%n_irr_point
-            if ( mod(iq,mw%n) .ne. mw%r ) cycle
-            nq=nq+1
-        enddo
+            nq = 0
+            do iq = 1, qp%n_irr_point
+                if (mod(iq, mw%n) .ne. mw%r) cycle
+                nq = nq + 1
+            end do
 
-        if ( nq .gt. 0 ) then
-            call mem%allocate(qvals,[nq,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(qproj,[uc%na,nq,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(qkappa,[nq,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            qvals=0.0_r8
-            qproj=0.0_r8
-            qkappa=0.0_r8
-            lq=0
-            do iq=1,qp%n_irr_point
-                if ( mod(iq,mw%n) .ne. mw%r ) cycle
-                lq=lq+1
-                do mode=1,dr%n_mode
-                    qvals(lq,mode)=dr%iq(iq)%omega(mode)
-                    do atom=1,uc%na
-                        cv0=dr%iq(iq)%egv( (atom-1)*3+1:atom*3 , mode )
-                        qproj(atom,lq,mode)=abs(dot_product(conjg(cv0),cv0))
-                    enddo
-                enddo
-            enddo
-        endif
+            if (nq .gt. 0) then
+                call mem%allocate(qvals, [nq, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(qproj, [uc%na, nq, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(qkappa, [nq, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                qvals = 0.0_r8
+                qproj = 0.0_r8
+                qkappa = 0.0_r8
+                lq = 0
+                do iq = 1, qp%n_irr_point
+                    if (mod(iq, mw%n) .ne. mw%r) cycle
+                    lq = lq + 1
+                    do mode = 1, dr%n_mode
+                        qvals(lq, mode) = dr%iq(iq)%omega(mode)
+                        do atom = 1, uc%na
+                            cv0 = dr%iq(iq)%egv((atom - 1)*3 + 1:atom*3, mode)
+                            qproj(atom, lq, mode) = abs(dot_product(conjg(cv0), cv0))
+                        end do
+                    end do
+                end do
+            end if
 
-        ! Do an actual integration. Should be the same integration type as before.
-        directionloop: do direction=1,9
-            ! skip irrelevant directions
-            if ( abs(kappa_total(direction)) .lt. kappatol ) cycle
-            ! Fetch kappa values
-            lq=0
-            do iq=1,qp%n_irr_point
-                if ( mod(iq,mw%n) .ne. mw%r ) cycle
-                lq=lq+1
-                ii=qp%ip(iq)%full_index
-                do mode=1,dr%n_mode
-                    qkappa(lq,mode)=kappa_flat(ii,mode,direction)
-                enddo
-            enddo
+            ! Do an actual integration. Should be the same integration type as before.
+            directionloop: do direction = 1, 9
+                ! skip irrelevant directions
+                if (abs(kappa_total(direction)) .lt. kappatol) cycle
+                ! Fetch kappa values
+                lq = 0
+                do iq = 1, qp%n_irr_point
+                    if (mod(iq, mw%n) .ne. mw%r) cycle
+                    lq = lq + 1
+                    ii = qp%ip(iq)%full_index
+                    do mode = 1, dr%n_mode
+                        qkappa(lq, mode) = kappa_flat(ii, mode, direction)
+                    end do
+                end do
 
-            ! Do the actual integration
-            invf=(pd%n_dos_point/maxval(pd%omega))
-            lq=0
-            do iq=1,qp%n_irr_point
-                if ( mod(iq,mw%n) .ne. mw%r ) cycle
-                lq=lq+1
-                weight=qp%ip(iq)%integration_weight
-                do mode=1,dr%n_mode
-                    f1=qvals(lq,mode) ! frequency
-                    if ( f1 .lt. dr%omega_min*0.5_r8 ) cycle
+                ! Do the actual integration
+                invf = (pd%n_dos_point/maxval(pd%omega))
+                lq = 0
+                do iq = 1, qp%n_irr_point
+                    if (mod(iq, mw%n) .ne. mw%r) cycle
+                    lq = lq + 1
+                    weight = qp%ip(iq)%integration_weight
+                    do mode = 1, dr%n_mode
+                        f1 = qvals(lq, mode) ! frequency
+                        if (f1 .lt. dr%omega_min*0.5_r8) cycle
 
-                    ! Get the smearing parameter
-                    select case(pd%integrationtype)
-                        case(1) ! fix gaussian
-                            sigma=dr%default_smearing(mode)*pd%smearing_prefactor
-                        case(2) ! adaptive gaussian
-                            sigma=qp%smearingparameter(dr%iq(iq)%vel(:,mode),dr%default_smearing(mode),pd%smearing_prefactor)
-                    end select
-                    foursigma=sigma*4
+                        ! Get the smearing parameter
+                        select case (pd%integrationtype)
+                        case (1) ! fix gaussian
+                            sigma = dr%default_smearing(mode)*pd%smearing_prefactor
+                        case (2) ! adaptive gaussian
+                            sigma = qp%smearingparameter(dr%iq(iq)%vel(:, mode), dr%default_smearing(mode), pd%smearing_prefactor)
+                        end select
+                        foursigma = sigma*4
 
-                    ! range of integration
-                    ii=max( floor( (f1-foursigma)*invf ), 1)
-                    jj=min( floor( (f1+foursigma)*invf ), pd%n_dos_point)
-                    do xval=ii,jj
-                        f0=lo_gauss(f1,pd%omega(xval),sigma)*weight
-                        spec_kappa_band(xval,mode,direction)=spec_kappa_band(xval,mode,direction)+qkappa(lq,mode)*f0
-                        do atom=1,uc%na
-                            spec_kappa_atom(xval,atom,direction)=spec_kappa_atom(xval,atom,direction)+qkappa(lq,mode)*qproj(atom,lq,mode)*f0
-                        enddo
-                    enddo
-                enddo
-            enddo
-        enddo directionloop
-        ! Add together
-        call mw%allreduce('sum',spec_kappa_atom)
-        call mw%allreduce('sum',spec_kappa_band)
-        ! And cleanup
-        if ( nq .gt. 0 ) then
-            call mem%deallocate(qvals,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(qproj,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(qkappa,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-        endif
-    end block gaussint
-    case(3) ! Tetrahedron integration
-    tetint: block
-        complex(r8), dimension(3) :: cv0
-        real(r8), dimension(:,:,:,:), allocatable :: tetproj
-        real(r8), dimension(:,:,:), allocatable :: tetvals,tetkappa
-        real(r8), dimension(4) :: w,tete
-        real(r8) :: sigma,mine,maxe,invf
-        integer :: i,l,mode,atom,xval,ii,jj,direction
-        integer :: itet,ltet,ntet
+                        ! range of integration
+                        ii = max(floor((f1 - foursigma)*invf), 1)
+                        jj = min(floor((f1 + foursigma)*invf), pd%n_dos_point)
+                        do xval = ii, jj
+                            f0 = lo_gauss(f1, pd%omega(xval), sigma)*weight
+                            spec_kappa_band(xval, mode, direction) = spec_kappa_band(xval, mode, direction) + qkappa(lq, mode)*f0
+                            do atom = 1, uc%na
+                                spec_kappa_atom(xval, atom, direction) = spec_kappa_atom(xval, atom, direction) + qkappa(lq, mode)*qproj(atom, lq, mode)*f0
+                            end do
+                        end do
+                    end do
+                end do
+            end do directionloop
+            ! Add together
+            call mw%allreduce('sum', spec_kappa_atom)
+            call mw%allreduce('sum', spec_kappa_band)
+            ! And cleanup
+            if (nq .gt. 0) then
+                call mem%deallocate(qvals, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(qproj, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(qkappa, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+            end if
+        end block gaussint
+    case (3) ! Tetrahedron integration
+        tetint: block
+            complex(r8), dimension(3) :: cv0
+            real(r8), dimension(:, :, :, :), allocatable :: tetproj
+            real(r8), dimension(:, :, :), allocatable :: tetvals, tetkappa
+            real(r8), dimension(4) :: w, tete
+            real(r8) :: sigma, mine, maxe, invf
+            integer :: i, l, mode, atom, xval, ii, jj, direction
+            integer :: itet, ltet, ntet
 
-        ! Count tetrahedrons per rank
-        ntet=0
-        do itet=1,qp%n_irr_tet
-            if ( mod(itet,mw%n) .eq. mw%r ) ntet=ntet+1
-        enddo
+            ! Count tetrahedrons per rank
+            ntet = 0
+            do itet = 1, qp%n_irr_tet
+                if (mod(itet, mw%n) .eq. mw%r) ntet = ntet + 1
+            end do
 
-        ! Pre-fetch data
-        if ( ntet .gt. 0 ) then
-            call mem%allocate(tetvals,[4,ntet,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(tetkappa,[4,ntet,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%allocate(tetproj,[4,uc%na,ntet,dr%n_mode],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            tetvals=0.0_r8
-            tetkappa=0.0_r8
-            tetproj=0.0_r8
-            ltet=0
-            do itet=1,qp%n_irr_tet
-                if ( mod(itet,mw%n) .ne. mw%r ) cycle
-                ltet=ltet+1
-                do i=1,4
-                    l=qp%it(itet)%full_index(i)
-                    do mode=1,dr%n_mode
-                        tetvals(i,ltet,mode)=dr%aq(l)%omega(mode)
-                        do atom=1,uc%na
-                            cv0=dr%aq(l)%egv( (atom-1)*3+1:atom*3 , mode )
-                            tetproj(i,atom,ltet,mode)=abs(dot_product(conjg(cv0),cv0))
-                        enddo
-                    enddo
-                enddo
-            enddo
-        endif
+            ! Pre-fetch data
+            if (ntet .gt. 0) then
+                call mem%allocate(tetvals, [4, ntet, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(tetkappa, [4, ntet, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%allocate(tetproj, [4, uc%na, ntet, dr%n_mode], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                tetvals = 0.0_r8
+                tetkappa = 0.0_r8
+                tetproj = 0.0_r8
+                ltet = 0
+                do itet = 1, qp%n_irr_tet
+                    if (mod(itet, mw%n) .ne. mw%r) cycle
+                    ltet = ltet + 1
+                    do i = 1, 4
+                        l = qp%it(itet)%full_index(i)
+                        do mode = 1, dr%n_mode
+                            tetvals(i, ltet, mode) = dr%aq(l)%omega(mode)
+                            do atom = 1, uc%na
+                                cv0 = dr%aq(l)%egv((atom - 1)*3 + 1:atom*3, mode)
+                                tetproj(i, atom, ltet, mode) = abs(dot_product(conjg(cv0), cv0))
+                            end do
+                        end do
+                    end do
+                end do
+            end if
 
-        spec_kappa_atom=0.0_r8
-        spec_kappa_band=0.0_r8
-        directionloop: do direction=1,9
-            ! kappa values for this direction
-            tetkappa=0.0_r8
-            ltet=0
-            do itet=1,qp%n_irr_tet
-                if ( mod(itet,mw%n) .ne. mw%r ) cycle
-                ltet=ltet+1
-                do i=1,4
-                    l=qp%it(itet)%full_index(i)
-                    do mode=1,dr%n_mode
-                        tetkappa(i,ltet,mode)=kappa_flat(l,mode,direction)
-                    enddo
-                enddo
-            enddo
+            spec_kappa_atom = 0.0_r8
+            spec_kappa_band = 0.0_r8
+            directionloop: do direction = 1, 9
+                ! kappa values for this direction
+                tetkappa = 0.0_r8
+                ltet = 0
+                do itet = 1, qp%n_irr_tet
+                    if (mod(itet, mw%n) .ne. mw%r) cycle
+                    ltet = ltet + 1
+                    do i = 1, 4
+                        l = qp%it(itet)%full_index(i)
+                        do mode = 1, dr%n_mode
+                            tetkappa(i, ltet, mode) = kappa_flat(l, mode, direction)
+                        end do
+                    end do
+                end do
 
-            invf=(pd%n_dos_point/maxval(pd%omega))
-            do mode=1,dr%n_mode
-                ltet=0
-                sigma=dr%default_smearing(mode)
-                do itet=1,qp%n_irr_tet
-                    if ( mod(itet,mw%n) .ne. mw%r ) cycle
-                    ltet=ltet+1
-                    tete=tetvals(:,ltet,mode)
-                    mine=minval(tete)
-                    maxe=maxval(tete)
-                    ii=max(floor( mine*invf ),1)
-                    jj=min(ceiling( maxe*invf ),pd%n_dos_point)
-                    do xval=ii,jj
-                        w=lo_LV_tetrahedron_weights(tete,pd%omega(xval),lo_freqtol,sigma)*qp%it(itet)%integration_weight
-                        spec_kappa_band(xval,mode,direction)=spec_kappa_band(xval,mode,direction)+sum(w*tetkappa(:,ltet,mode))
-                        do atom=1,uc%na
-                            spec_kappa_atom(xval,atom,direction)=spec_kappa_atom(xval,atom,direction)+sum(w*tetkappa(:,ltet,mode)*tetproj(:,atom,ltet,mode))
-                        enddo
-                    enddo
-                enddo
-            enddo
-        enddo directionloop
-        call mw%allreduce('sum',spec_kappa_atom)
-        call mw%allreduce('sum',spec_kappa_band)
-        if ( ntet .gt. 0 ) then
-            call mem%deallocate(tetvals,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(tetkappa,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-            call mem%deallocate(tetproj,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-        endif
-    end block tetint
+                invf = (pd%n_dos_point/maxval(pd%omega))
+                do mode = 1, dr%n_mode
+                    ltet = 0
+                    sigma = dr%default_smearing(mode)
+                    do itet = 1, qp%n_irr_tet
+                        if (mod(itet, mw%n) .ne. mw%r) cycle
+                        ltet = ltet + 1
+                        tete = tetvals(:, ltet, mode)
+                        mine = minval(tete)
+                        maxe = maxval(tete)
+                        ii = max(floor(mine*invf), 1)
+                        jj = min(ceiling(maxe*invf), pd%n_dos_point)
+                        do xval = ii, jj
+                            w = lo_LV_tetrahedron_weights(tete, pd%omega(xval), lo_freqtol, sigma)*qp%it(itet)%integration_weight
+                            spec_kappa_band(xval, mode, direction) = spec_kappa_band(xval, mode, direction) + sum(w*tetkappa(:, ltet, mode))
+                            do atom = 1, uc%na
+                                spec_kappa_atom(xval, atom, direction) = spec_kappa_atom(xval, atom, direction) + sum(w*tetkappa(:, ltet, mode)*tetproj(:, atom, ltet, mode))
+                            end do
+                        end do
+                    end do
+                end do
+            end do directionloop
+            call mw%allreduce('sum', spec_kappa_atom)
+            call mw%allreduce('sum', spec_kappa_band)
+            if (ntet .gt. 0) then
+                call mem%deallocate(tetvals, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(tetkappa, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+                call mem%deallocate(tetproj, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+            end if
+        end block tetint
     case default
-        call lo_stop_gracefully(['Unknown integration type'],lo_exitcode_param,__FILE__,__LINE__,mw%comm)
+        call lo_stop_gracefully(['Unknown integration type'], lo_exitcode_param, __FILE__, __LINE__, mw%comm)
     end select
 
     ! Now make the spectrum look a little nicer.
     makenice: block
-        integer, parameter :: nkernel=6
+        integer, parameter :: nkernel = 6
         real(r8), dimension(-nkernel:nkernel) :: kernel
         real(r8), dimension(:), allocatable :: ysm
-        real(r8) :: f0,f1,f2
-        integer :: direction,i,j,k,atom,mode
+        real(r8) :: f0, f1, f2
+        integer :: direction, i, j, k, atom, mode
 
         ! Prepare the smearing kernel
-        do i=-nkernel,nkernel
-            kernel(i)=lo_gauss(0.0_r8,i*1.0_r8,1.5_r8)
-        enddo
-        kernel=kernel/sum(kernel)
-        allocate(ysm(-nkernel:pd%n_dos_point+nkernel))
-        ysm=0.0_r8
+        do i = -nkernel, nkernel
+            kernel(i) = lo_gauss(0.0_r8, i*1.0_r8, 1.5_r8)
+        end do
+        kernel = kernel/sum(kernel)
+        allocate (ysm(-nkernel:pd%n_dos_point + nkernel))
+        ysm = 0.0_r8
 
         ! Must be positive, I think.
-        spec_kappa_atom=max(spec_kappa_atom,0.0_r8)
-        spec_kappa_band=max(spec_kappa_band,0.0_r8)
+        spec_kappa_atom = max(spec_kappa_atom, 0.0_r8)
+        spec_kappa_band = max(spec_kappa_band, 0.0_r8)
 
-        dirloop: do direction=1,9
-            if ( kappa_total(direction) .lt. kappatol ) cycle
+        dirloop: do direction = 1, 9
+            if (kappa_total(direction) .lt. kappatol) cycle
 
             ! Smear things slightly
-            do atom=1,uc%na
-                ysm=0.0_r8
-                do i=1,pd%n_dos_point
-                do j=-nkernel,nkernel
-                    ysm(i+j)=ysm(i+j)+kernel(j)*spec_kappa_atom(i,atom,direction)
-                enddo
-                enddo
-                spec_kappa_atom(:,atom,direction)=ysm(1:pd%n_dos_point)
-            enddo
-            do mode=1,dr%n_mode
-                ysm=0.0_r8
-                do i=1,pd%n_dos_point
-                do j=-nkernel,nkernel
-                    ysm(i+j)=ysm(i+j)+kernel(j)*spec_kappa_band(i,mode,direction)
-                enddo
-                enddo
-                spec_kappa_band(:,mode,direction)=ysm(1:pd%n_dos_point)
-            enddo
+            do atom = 1, uc%na
+                ysm = 0.0_r8
+                do i = 1, pd%n_dos_point
+                do j = -nkernel, nkernel
+                    ysm(i + j) = ysm(i + j) + kernel(j)*spec_kappa_atom(i, atom, direction)
+                end do
+                end do
+                spec_kappa_atom(:, atom, direction) = ysm(1:pd%n_dos_point)
+            end do
+            do mode = 1, dr%n_mode
+                ysm = 0.0_r8
+                do i = 1, pd%n_dos_point
+                do j = -nkernel, nkernel
+                    ysm(i + j) = ysm(i + j) + kernel(j)*spec_kappa_band(i, mode, direction)
+                end do
+                end do
+                spec_kappa_band(:, mode, direction) = ysm(1:pd%n_dos_point)
+            end do
 
             ! Fix site degeneracies
-            do i=1,uc%na
-                ysm=0.0_r8
-                do j=1,uc%sym%degeneracy(i)
-                    k=uc%sym%degenerate_atom(j,i)
-                    ysm(1:pd%n_dos_point)=ysm(1:pd%n_dos_point)+spec_kappa_atom(:,i,direction)/(1.0_r8*uc%sym%degeneracy(i))
-                enddo
-                do j=1,uc%sym%degeneracy(i)
-                    k=uc%sym%degenerate_atom(j,i)
-                    spec_kappa_atom(:,k,direction)=ysm(1:pd%n_dos_point)
-                enddo
-            enddo
+            do i = 1, uc%na
+                ysm = 0.0_r8
+                do j = 1, uc%sym%degeneracy(i)
+                    k = uc%sym%degenerate_atom(j, i)
+                    ysm(1:pd%n_dos_point) = ysm(1:pd%n_dos_point) + spec_kappa_atom(:, i, direction)/(1.0_r8*uc%sym%degeneracy(i))
+                end do
+                do j = 1, uc%sym%degeneracy(i)
+                    k = uc%sym%degenerate_atom(j, i)
+                    spec_kappa_atom(:, k, direction) = ysm(1:pd%n_dos_point)
+                end do
+            end do
 
             ! Has to be zero at zero
-            do atom=1,uc%na
-                f0=spec_kappa_atom(1,atom,direction)
-                do i=1,pd%n_dos_point
-                    f1=1.0_r8-(i-1.0_r8)/real(pd%n_dos_point-1,r8)
-                    spec_kappa_atom(i,atom,direction)=max(spec_kappa_atom(i,atom,direction)-f1*f0,0.0_r8)
-                enddo
-                spec_kappa_atom(1,atom,direction)=0.0_r8
-            enddo
-            do mode=1,dr%n_mode
-                f0=spec_kappa_band(1,mode,direction)
-                do i=1,pd%n_dos_point
-                    f1=1.0_r8-(i-1.0_r8)/real(pd%n_dos_point-1,r8)
-                    spec_kappa_band(i,mode,direction)=max(spec_kappa_band(i,mode,direction)-f1*f0,0.0_r8)
-                enddo
-                spec_kappa_band(1,mode,direction)=0.0_r8
-            enddo
+            do atom = 1, uc%na
+                f0 = spec_kappa_atom(1, atom, direction)
+                do i = 1, pd%n_dos_point
+                    f1 = 1.0_r8 - (i - 1.0_r8)/real(pd%n_dos_point - 1, r8)
+                    spec_kappa_atom(i, atom, direction) = max(spec_kappa_atom(i, atom, direction) - f1*f0, 0.0_r8)
+                end do
+                spec_kappa_atom(1, atom, direction) = 0.0_r8
+            end do
+            do mode = 1, dr%n_mode
+                f0 = spec_kappa_band(1, mode, direction)
+                do i = 1, pd%n_dos_point
+                    f1 = 1.0_r8 - (i - 1.0_r8)/real(pd%n_dos_point - 1, r8)
+                    spec_kappa_band(i, mode, direction) = max(spec_kappa_band(i, mode, direction) - f1*f0, 0.0_r8)
+                end do
+                spec_kappa_band(1, mode, direction) = 0.0_r8
+            end do
 
             ! Add up to total, and normalize properly
-            spec_kappa(:,direction)=0.0_r8
-            do mode=1,dr%n_mode
-                spec_kappa(:,direction)=spec_kappa(:,direction)+spec_kappa_band(:,mode,direction)
-            enddo
-            f0=lo_trapezoid_integration(pd%omega,spec_kappa(:,direction))
-            if ( f0 .gt. kappatol ) then
-                spec_kappa(:,direction)=spec_kappa(:,direction)*kappa_total(direction)/f0
+            spec_kappa(:, direction) = 0.0_r8
+            do mode = 1, dr%n_mode
+                spec_kappa(:, direction) = spec_kappa(:, direction) + spec_kappa_band(:, mode, direction)
+            end do
+            f0 = lo_trapezoid_integration(pd%omega, spec_kappa(:, direction))
+            if (f0 .gt. kappatol) then
+                spec_kappa(:, direction) = spec_kappa(:, direction)*kappa_total(direction)/f0
             else
-                spec_kappa(:,direction)=0.0_r8
-            endif
+                spec_kappa(:, direction) = 0.0_r8
+            end if
 
             ! Make sure the projected add up to the total.
-            do i=1,pd%n_dos_point
-                f0=sum(spec_kappa_atom(i,:,direction))
-                f1=sum(spec_kappa_band(i,:,direction))
-                f2=spec_kappa(i,direction)
+            do i = 1, pd%n_dos_point
+                f0 = sum(spec_kappa_atom(i, :, direction))
+                f1 = sum(spec_kappa_band(i, :, direction))
+                f2 = spec_kappa(i, direction)
                 ! make sure there is finite kappa
-                if ( f2 .gt. kappatol ) then
-                    if ( f0 .gt. kappatol ) then
-                        spec_kappa_atom(i,:,direction)=spec_kappa_atom(i,:,direction)*f2/f0
+                if (f2 .gt. kappatol) then
+                    if (f0 .gt. kappatol) then
+                        spec_kappa_atom(i, :, direction) = spec_kappa_atom(i, :, direction)*f2/f0
                     else
-                        spec_kappa_atom(i,:,direction)=0.0_r8
-                    endif
-                    if ( f1 .gt. kappatol ) then
-                        spec_kappa_band(i,:,direction)=spec_kappa_band(i,:,direction)*f2/f1
+                        spec_kappa_atom(i, :, direction) = 0.0_r8
+                    end if
+                    if (f1 .gt. kappatol) then
+                        spec_kappa_band(i, :, direction) = spec_kappa_band(i, :, direction)*f2/f1
                     else
-                        spec_kappa_band(i,:,direction)=0.0_r8
-                    endif
+                        spec_kappa_band(i, :, direction) = 0.0_r8
+                    end if
                 else
-                    spec_kappa(i,direction)=0.0_r8
-                    spec_kappa_band(i,:,direction)=0.0_r8
-                    spec_kappa_atom(i,:,direction)=0.0_r8
-                endif
-            enddo
-        enddo dirloop
-        deallocate(ysm)
+                    spec_kappa(i, direction) = 0.0_r8
+                    spec_kappa_band(i, :, direction) = 0.0_r8
+                    spec_kappa_atom(i, :, direction) = 0.0_r8
+                end if
+            end do
+        end do dirloop
+        deallocate (ysm)
     end block makenice
 end subroutine
 
 !> Integrate the phonon dos with the tetrahedron method
-module subroutine lo_get_phonon_dos_tetrahedron(pd,qp,dr,mw,mem,verbosity)
+module subroutine lo_get_phonon_dos_tetrahedron(pd, qp, dr, mw, mem, verbosity)
     !> phonon dos
     type(lo_phonon_dos), intent(inout) :: pd
     !> q-point mesh
@@ -824,107 +824,107 @@ module subroutine lo_get_phonon_dos_tetrahedron(pd,qp,dr,mw,mem,verbosity)
     integer, intent(in) :: verbosity
 
     complex(r8), dimension(3) :: v0
-    real(r8), dimension(:,:,:), allocatable :: tetenergies
-    real(r8), dimension(:,:,:), allocatable :: tetsiteproj
-    real(r8), dimension(4) :: tete,w1,w2
-    real(r8) :: e,f0,deltae,sigma,t0,mine,maxe,totmaxe,totmine,invf
-    integer :: i,j,k,l,ii,jj,ntet,li
+    real(r8), dimension(:, :, :), allocatable :: tetenergies
+    real(r8), dimension(:, :, :), allocatable :: tetsiteproj
+    real(r8), dimension(4) :: tete, w1, w2
+    real(r8) :: e, f0, deltae, sigma, t0, mine, maxe, totmaxe, totmine, invf
+    integer :: i, j, k, l, ii, jj, ntet, li
 
     ! Miniscule smearing
-    deltae=(pd%omega(2)-pd%omega(1))*0.5_r8
+    deltae = (pd%omega(2) - pd%omega(1))*0.5_r8
 
     ! Count number of tetrahedrons on this rank.
-    ntet=0
-    do i=1,qp%n_irr_tet
-        if ( mod(i,mw%n) .ne. mw%r ) cycle
-        ntet=ntet+1
-    enddo
+    ntet = 0
+    do i = 1, qp%n_irr_tet
+        if (mod(i, mw%n) .ne. mw%r) cycle
+        ntet = ntet + 1
+    end do
 
     ! Pre-fetch things for tetrahedrons
-    if ( ntet .gt. 0 ) then
-        call mem%allocate(tetenergies,[4,dr%n_mode,ntet],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-        call mem%allocate(tetsiteproj,[pd%n_atom,dr%n_mode,ntet],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
+    if (ntet .gt. 0) then
+        call mem%allocate(tetenergies, [4, dr%n_mode, ntet], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+        call mem%allocate(tetsiteproj, [pd%n_atom, dr%n_mode, ntet], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
     else
-        call mem%allocate(tetenergies,[1,1,1],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-        call mem%allocate(tetsiteproj,[1,1,1],persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-    endif
-    tetenergies=0.0_r8
-    tetsiteproj=0.0_r8
-    li=0
-    do i=1,qp%n_irr_tet
-        if ( mod(i,mw%n) .ne. mw%r ) cycle
-        li=li+1
-        do j=1,4
+        call mem%allocate(tetenergies, [1, 1, 1], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+        call mem%allocate(tetsiteproj, [1, 1, 1], persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+    end if
+    tetenergies = 0.0_r8
+    tetsiteproj = 0.0_r8
+    li = 0
+    do i = 1, qp%n_irr_tet
+        if (mod(i, mw%n) .ne. mw%r) cycle
+        li = li + 1
+        do j = 1, 4
             ! energies
-            l=qp%it(i)%irreducible_index(j)
-            do k=1,dr%n_mode
-                tetenergies(j,k,li)=dr%iq(l)%omega(k)
-            enddo
+            l = qp%it(i)%irreducible_index(j)
+            do k = 1, dr%n_mode
+                tetenergies(j, k, li) = dr%iq(l)%omega(k)
+            end do
             ! projections
-            do ii=1,pd%n_atom
-            do jj=1,dr%n_mode
-                v0=dr%iq(l)%egv((ii-1)*3+1:ii*3,jj)
-                tetsiteproj(ii,jj,li)=tetsiteproj(ii,jj,li)+abs(dot_product(v0,v0))
-            enddo
-            enddo
-        enddo
-    enddo
+            do ii = 1, pd%n_atom
+            do jj = 1, dr%n_mode
+                v0 = dr%iq(l)%egv((ii - 1)*3 + 1:ii*3, jj)
+                tetsiteproj(ii, jj, li) = tetsiteproj(ii, jj, li) + abs(dot_product(v0, v0))
+            end do
+            end do
+        end do
+    end do
 
     ! ! Do the actual integration
-    totmaxe=maxval(pd%omega)
-    totmine=minval(pd%omega)
-    invf=(pd%n_dos_point/(totmaxe-totmine))
+    totmaxe = maxval(pd%omega)
+    totmine = minval(pd%omega)
+    invf = (pd%n_dos_point/(totmaxe - totmine))
     !foursigma=4*sigma
-    t0=walltime()
+    t0 = walltime()
     ! Start by looping over tetrahedrons, I believe is smart.
-    pd%pdos_site=0.0_r8
-    pd%pdos_mode=0.0_r8
-    if ( verbosity .gt. 0 ) call lo_progressbar_init()
-    li=0
-    do i=1,qp%n_irr_tet
-        if ( mod(i,mw%n) .ne. mw%r ) cycle
-        li=li+1
-        do j=1,dr%n_mode
+    pd%pdos_site = 0.0_r8
+    pd%pdos_mode = 0.0_r8
+    if (verbosity .gt. 0) call lo_progressbar_init()
+    li = 0
+    do i = 1, qp%n_irr_tet
+        if (mod(i, mw%n) .ne. mw%r) cycle
+        li = li + 1
+        do j = 1, dr%n_mode
             ! smearing for degenerate tetrahedrons
-            sigma=dr%default_smearing(j)
+            sigma = dr%default_smearing(j)
             ! smallest and largest tetrahedron energies, expressed as indices in the energy-axis
-            tete=tetenergies(:,j,li)
-            mine=minval(tete)-totmine
-            maxe=maxval(tete)-totmine
-            ii=max(floor( mine*invf ),1)
-            jj=min(ceiling( maxe*invf ),pd%n_dos_point)
+            tete = tetenergies(:, j, li)
+            mine = minval(tete) - totmine
+            maxe = maxval(tete) - totmine
+            ii = max(floor(mine*invf), 1)
+            jj = min(ceiling(maxe*invf), pd%n_dos_point)
             ! loop over energy
-            do k=ii,jj
+            do k = ii, jj
                 ! integration weights
-                e=pd%omega(k)
-                w1=lo_LV_tetrahedron_weights(tete,e-deltae,lo_freqtol,sigma)
-                w2=lo_LV_tetrahedron_weights(tete,e+deltae,lo_freqtol,sigma)
-                f0=sum(w1+w2)*qp%it(i)%integration_weight*0.5_r8
+                e = pd%omega(k)
+                w1 = lo_LV_tetrahedron_weights(tete, e - deltae, lo_freqtol, sigma)
+                w2 = lo_LV_tetrahedron_weights(tete, e + deltae, lo_freqtol, sigma)
+                f0 = sum(w1 + w2)*qp%it(i)%integration_weight*0.5_r8
                 ! Increment things
-                pd%pdos_mode(k,j)=pd%pdos_mode(k,j)+f0
-                do l=1,pd%n_atom
-                    pd%pdos_site(k,l)=pd%pdos_site(k,l)+tetsiteproj(l,j,li)*f0
-                enddo
-            enddo
-        enddo
-        if ( verbosity .gt. 0 ) then
-            if ( lo_trueNtimes(li,63,ntet) ) call lo_progressbar(' ... integrating phonon DOS',li,ntet)
-        endif
-    enddo
+                pd%pdos_mode(k, j) = pd%pdos_mode(k, j) + f0
+                do l = 1, pd%n_atom
+                    pd%pdos_site(k, l) = pd%pdos_site(k, l) + tetsiteproj(l, j, li)*f0
+                end do
+            end do
+        end do
+        if (verbosity .gt. 0) then
+            if (lo_trueNtimes(li, 63, ntet)) call lo_progressbar(' ... integrating phonon DOS', li, ntet)
+        end if
+    end do
     ! sum them up over ranks
-    call mw%allreduce('sum',pd%pdos_mode)
-    call mw%allreduce('sum',pd%pdos_site)
+    call mw%allreduce('sum', pd%pdos_mode)
+    call mw%allreduce('sum', pd%pdos_site)
     ! Cleanup
-    call mem%deallocate(tetenergies,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
-    call mem%deallocate(tetsiteproj,persistent=.false.,scalable=.true.,file=__FILE__,line=__LINE__)
+    call mem%deallocate(tetenergies, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
+    call mem%deallocate(tetsiteproj, persistent=.false., scalable=.true., file=__FILE__, line=__LINE__)
     ! finalize the message
-    if ( verbosity .gt. 0 ) then
-        call lo_progressbar(' ... integrating phonon DOS',ntet,ntet,walltime()-t0)
-    endif
+    if (verbosity .gt. 0) then
+        call lo_progressbar(' ... integrating phonon DOS', ntet, ntet, walltime() - t0)
+    end if
 end subroutine
 
 !> Calculate the phonon dos with Gaussian smearing, either fixed or adaptive
-module subroutine lo_get_phonon_dos_gaussian(pd,qp,dr,mw,verbosity)
+module subroutine lo_get_phonon_dos_gaussian(pd, qp, dr, mw, verbosity)
     !> phonon dos
     type(lo_phonon_dos), intent(inout) :: pd
     !> q-point grid
@@ -937,56 +937,56 @@ module subroutine lo_get_phonon_dos_gaussian(pd,qp,dr,mw,verbosity)
     integer, intent(in) :: verbosity
 
     complex(r8), dimension(3) :: v0
-    integer, parameter :: nsigma=4
-    real(r8), parameter :: sigmacorr=1.000063346496191_r8
+    integer, parameter :: nsigma = 4
+    real(r8), parameter :: sigmacorr = 1.000063346496191_r8
     real(r8), dimension(:), allocatable :: dy
     real(r8), dimension(pd%n_atom) :: siteweight
-    real(r8) :: f0,f1,sigma,weight,t0,totmaxe,totmine,invf,foursigma
-    integer :: j,k,l,ii,jj,q
+    real(r8) :: f0, f1, sigma, weight, t0, totmaxe, totmine, invf, foursigma
+    integer :: j, k, l, ii, jj, q
     integer :: ctr
 
-    t0=walltime()
+    t0 = walltime()
     ! some shortand energies
-    totmaxe=maxval(pd%omega)
-    totmine=minval(pd%omega)
-    invf=(pd%n_dos_point/(totmaxe-totmine))
-    pd%pdos_site=0.0_r8
-    pd%pdos_mode=0.0_r8
+    totmaxe = maxval(pd%omega)
+    totmine = minval(pd%omega)
+    invf = (pd%n_dos_point/(totmaxe - totmine))
+    pd%pdos_site = 0.0_r8
+    pd%pdos_mode = 0.0_r8
 
-    allocate(dy(pd%n_dos_point))
+    allocate (dy(pd%n_dos_point))
     ! Integration
-    ctr=0
-    if ( verbosity .gt. 1 ) call lo_progressbar_init()
-    do q=1,qp%n_irr_point
-        weight=qp%ip(q)%integration_weight
-        do j=1,dr%n_mode
-            ctr=ctr+1
+    ctr = 0
+    if (verbosity .gt. 1) call lo_progressbar_init()
+    do q = 1, qp%n_irr_point
+        weight = qp%ip(q)%integration_weight
+        do j = 1, dr%n_mode
+            ctr = ctr + 1
             ! Make it parallel
-            if ( mod(ctr,mw%n) .ne. mw%r ) cycle
+            if (mod(ctr, mw%n) .ne. mw%r) cycle
 
             ! Get the current frequency
-            f1=dr%iq(q)%omega(j)
-            if ( f1 .lt. dr%omega_min*0.5_r8 ) cycle
+            f1 = dr%iq(q)%omega(j)
+            if (f1 .lt. dr%omega_min*0.5_r8) cycle
 
             ! Get the smearing parameter
-            select case(pd%integrationtype)
-                case(1) ! fix gaussian
-                    sigma=dr%default_smearing(j)*pd%smearing_prefactor
-                case(2) ! adaptive gaussian
-                    sigma=qp%adaptive_sigma( qp%ip(q)%radius,dr%iq(q)%vel(:,j),dr%default_smearing(j),pd%smearing_prefactor )
-                    !sigma=qp%smearingparameter(dr%iq(q)%vel(:,j),dr%default_smearing(j),pd%smearing_prefactor)
+            select case (pd%integrationtype)
+            case (1) ! fix gaussian
+                sigma = dr%default_smearing(j)*pd%smearing_prefactor
+            case (2) ! adaptive gaussian
+                sigma = qp%adaptive_sigma(qp%ip(q)%radius, dr%iq(q)%vel(:, j), dr%default_smearing(j), pd%smearing_prefactor)
+                !sigma=qp%smearingparameter(dr%iq(q)%vel(:,j),dr%default_smearing(j),pd%smearing_prefactor)
             end select
-            foursigma=sigma*nsigma
+            foursigma = sigma*nsigma
 
             ! Fetch projection thingy
-            do ii=1,pd%n_atom
-                v0=dr%iq(q)%egv( (ii-1)*3+1:ii*3, j )
-                siteweight(ii)=abs(dot_product(v0,conjg(v0)))
-            enddo
+            do ii = 1, pd%n_atom
+                v0 = dr%iq(q)%egv((ii - 1)*3 + 1:ii*3, j)
+                siteweight(ii) = abs(dot_product(v0, conjg(v0)))
+            end do
 
             ! range of integration
-            ii=max( floor( (f1-totmine-foursigma)*invf ), 1)
-            jj=min( floor( (f1-totmine+foursigma)*invf ), pd%n_dos_point)
+            ii = max(floor((f1 - totmine - foursigma)*invf), 1)
+            jj = min(floor((f1 - totmine + foursigma)*invf), pd%n_dos_point)
             ! do k=ii,jj
             !     f0=lo_gauss(f1,pd%omega(k),sigma)*weight*sigmacorr
             !     pd%pdos_mode(k,j)=pd%pdos_mode(k,j)+f0
@@ -996,44 +996,44 @@ module subroutine lo_get_phonon_dos_gaussian(pd,qp,dr,mw,verbosity)
             ! enddo
 
             ! how about being really anal and make sure we are actually normalized every single time?
-            dy=0.0_r8
-            do k=ii,jj
-                dy(k)=lo_gauss(f1,pd%omega(k),sigma)
-            enddo
-            pd%pdos_mode(ii:jj,j)=pd%pdos_mode(ii:jj,j)+dy(ii:jj)*weight !*sigmacorr
-            do l=1,pd%n_atom
-                pd%pdos_site(ii:jj,l)=pd%pdos_site(ii:jj,l)+dy(ii:jj)*siteweight(l)
-            enddo
+            dy = 0.0_r8
+            do k = ii, jj
+                dy(k) = lo_gauss(f1, pd%omega(k), sigma)
+            end do
+            pd%pdos_mode(ii:jj, j) = pd%pdos_mode(ii:jj, j) + dy(ii:jj)*weight !*sigmacorr
+            do l = 1, pd%n_atom
+                pd%pdos_site(ii:jj, l) = pd%pdos_site(ii:jj, l) + dy(ii:jj)*siteweight(l)
+            end do
 
-        enddo
-        if ( verbosity .gt. 0 ) then
-            if ( lo_trueNtimes(q,63,qp%n_irr_point) ) call lo_progressbar(' ... integrating phonon DOS',q,qp%n_irr_point)
-        endif
-    enddo
+        end do
+        if (verbosity .gt. 0) then
+            if (lo_trueNtimes(q, 63, qp%n_irr_point)) call lo_progressbar(' ... integrating phonon DOS', q, qp%n_irr_point)
+        end if
+    end do
     ! sum them up over ranks
-    deallocate(dy)
-    call mw%allreduce('sum',pd%pdos_site)
-    call mw%allreduce('sum',pd%pdos_mode)
+    deallocate (dy)
+    call mw%allreduce('sum', pd%pdos_site)
+    call mw%allreduce('sum', pd%pdos_mode)
 
-    if ( verbosity .gt. 0 ) then
-        call lo_progressbar(' ... integrating phonon DOS',qp%n_irr_point,qp%n_irr_point,walltime()-t0)
-    endif
+    if (verbosity .gt. 0) then
+        call lo_progressbar(' ... integrating phonon DOS', qp%n_irr_point, qp%n_irr_point, walltime() - t0)
+    end if
 end subroutine
 
 ! some old thing I got from someone. Not sure about it.
 real(r8) function ARCSenergyresolution(omega)
     real(r8), intent(in) :: omega
-    real(r8) :: E,f0,a0,a1,a2,a3,a4
+    real(r8) :: E, f0, a0, a1, a2, a3, a4
 
-    a0 =  1.8821603859_r8
+    a0 = 1.8821603859_r8
     a1 = -3.8232422875e-2_r8
-    a2 =  1.7805244237e-4_r8
-    a3 =  1.1792351443e-6_r8
-    a4 =  1.2642974944e-8_r8
-    E=omega*lo_frequency_hartree_to_meV
+    a2 = 1.7805244237e-4_r8
+    a3 = 1.1792351443e-6_r8
+    a4 = 1.2642974944e-8_r8
+    E = omega*lo_frequency_hartree_to_meV
 
-    f0=(a0+a1*E+a2*E**2+a3*E**3+a4*E**4)/2.35_r8
-    ARCSenergyresolution=f0/lo_frequency_hartree_to_meV
+    f0 = (a0 + a1*E + a2*E**2 + a3*E**3 + a4*E**4)/2.35_r8
+    ARCSenergyresolution = f0/lo_frequency_hartree_to_meV
 end function
 
 end submodule

--- a/src/phonon_dispersion_relations/main.f90
+++ b/src/phonon_dispersion_relations/main.f90
@@ -310,6 +310,7 @@ end if
 
 ! Print some file and wrap it up
 wrapup: block
+    character(len=1000) :: buf
     ! Write everything on the grid to file, for some inexplicable reason.
     if (opts%dumpgrid) then
         ! small sanity check
@@ -322,8 +323,13 @@ wrapup: block
         end if
         ! actually write it
         if (mw%talk) then
-            call dr%write_to_hdf5(qp, uc, 'outfile.grid_dispersions.hdf5', mem)
-            write (*, *) '... wrote data for the full grid'
+            buf = 'outfile.grid_dispersions_irreducible.hdf5'
+            call dr%write_irreducible_to_hdf5(qp, uc, trim(buf), mem)
+            write (*, *) "... wrote data for the irreducible grid to '", trim(buf), "'"
+
+            buf = 'outfile.grid_dispersions.hdf5'
+            call dr%write_to_hdf5(qp, uc, trim(buf), mem)
+            write (*, *) "... wrote data for the full grid to        '", trim(buf), "'"
         end if
     end if
 

--- a/src/phonon_dispersion_relations/options.f90
+++ b/src/phonon_dispersion_relations/options.f90
@@ -115,7 +115,7 @@ subroutine parse(opts)
                  required=.false., act='store_true', def='.false.', error=lo_status)
     if (lo_status .ne. 0) stop
     call cli%add(switch='--dumpgrid', &
-                 help='Write files with q-vectors, frequencies, eigenvectors and group velocities for a grid.', &
+                 help='Write files with q-vectors, frequencies, eigenvectors and group velocities for the irreducible and full grid.', &
                  required=.false., act='store_true', def='.false.', error=lo_status)
     if (lo_status .ne. 0) stop
 


### PR DESCRIPTION
Write dispersion on irreducible grid to HDF5 file `outfile.grid_dispersions_irreducible.hdf5` in addition to the full grid information in `outfile.grid_dispersions.hdf5`. This is useful, e.g., to compute the 2PDOS.