### PR TITLE
Fix broadening for thermal conductivity

### DIFF
--- a/src/thermal_conductivity/kappa.f90
+++ b/src/thermal_conductivity/kappa.f90
@@ -257,6 +257,7 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
                 if (dr%iq(iq)%omega(jmode) .lt. lo_freqtol) cycle
                 om1 = dr%iq(iq)%omega(jmode)
                 tau1 = dr%iq(iq)%linewidth(jmode)
+                if (tau1 .lt. lo_freqtol) cycle
                 do kmode = 1, dr%n_mode
                     if (jmode .eq. kmode) cycle  ! We only want the off diagonal contribution
                     ! Skip gamma for acoustic branches
@@ -264,6 +265,7 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
                     if (om2 .lt. lo_freqtol) cycle
 
                     tau2 = dr%iq(iq)%linewidth(kmode)
+                    if (tau2 .lt. lo_freqtol) cycle
 
                     ! This is consistent with the paper, but a bit different from QHGK
                     ! This comes from the fact that we don't work with creation/annihilation but
@@ -412,7 +414,11 @@ subroutine iterative_solution(sr, dr, qp, uc, temperature, niter, tol, classical
             do il = 1, sr%my_nqpoints
                 q1 = sr%my_qpoints(il)
                 b1 = sr%my_modes(il)
-                Fnb(:, b1, q1) = -buf(:, il)/dr%iq(q1)%qs(b1)
+                if (dr%iq(q1)%qs(b1) .lt. lo_freqtol) then
+                    Fnb(:, b1, q1) = 0.0_r8
+                else
+                    Fnb(:, b1, q1) = -buf(:, il)/dr%iq(q1)%qs(b1)
+                end if
             end do
             call mw%allreduce('sum', Fnb)
         end block applyXi

--- a/src/thermal_conductivity/kappa.f90
+++ b/src/thermal_conductivity/kappa.f90
@@ -1,7 +1,7 @@
 #include "precompilerdefinitions"
 module kappa
 use konstanter, only: r8, lo_sqtol, lo_kb_hartree, lo_freqtol, lo_kappa_au_to_SI, &
-                      lo_groupvel_Hartreebohr_to_ms
+                      lo_groupvel_Hartreebohr_to_ms, lo_twopi
 use gottochblandat, only: lo_sqnorm, lo_planck, lo_outerproduct, lo_chop, lo_harmonic_oscillator_cv
 use mpi_wrappers, only: lo_mpi_helper
 use lo_memtracker, only: lo_mem_helper
@@ -22,6 +22,7 @@ public :: get_kappa
 public :: get_kappa_offdiag
 public :: iterative_solution
 public :: symmetrize_kappa
+public :: get_viscosity
 contains
 
 !> Calculate the thermal conductivity
@@ -483,5 +484,61 @@ subroutine iterative_solution(sr, dr, qp, uc, temperature, niter, tol, classical
     call mem%deallocate(Fnb, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(Fbb, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(buf, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+end subroutine
+
+!> Calculate the thermal conductivity
+subroutine get_viscosity(dr, qp, uc, temperature, classical, mu)
+    !> dispersions
+    type(lo_phonon_dispersions), intent(inout) :: dr
+    !> q-mesh
+    class(lo_qpoint_mesh), intent(in) :: qp
+    !> structure
+    type(lo_crystalstructure), intent(in) :: uc
+    !> temperature
+    real(r8), intent(in) :: temperature
+    !> Are we in the classical limit ?
+    logical, intent(in) :: classical
+    !> thermal conductivity tensor
+    real(r8), dimension(3, 3, 3, 3), intent(out) :: mu
+
+    real(r8), dimension(3) :: v0, v1, kr
+    real(r8) :: om1, cv, pref, n
+    integer :: j
+
+    integer :: q1, b1, iq, a, b, c, d, iop
+    real(r8), dimension(3, 3) :: v2, buf
+
+    mu = 0.0_r8
+    do q1=1, qp%n_full_point
+        iq = qp%ap(q1)%irreducible_index
+        kr = qp%ap(q1)%r * lo_twopi
+        iop = qp%ap(q1)%operation_from_irreducible
+        do b1=1, dr%n_mode
+            om1 = dr%aq(q1)%omega(b1)
+            if (om1 .lt. lo_freqtol) cycle
+            n = lo_planck(temperature, om1)
+            pref = n * (n + 1.0_r8) / uc%volume / lo_kb_hartree / temperature
+            v2 = 0.0_r8
+            if (iop .gt. 0) then
+                v0 = lo_operate_on_vector(uc%sym%op(iop), dr%iq(iq)%Fn(:, b1))
+                v1 = lo_operate_on_vector(uc%sym%op(iop), dr%iq(iq)%vel(:, b1))
+            else
+                v0 = -lo_operate_on_vector(uc%sym%op(abs(iop)), dr%iq(iq)%Fn(:, b1))
+                v1 = -lo_operate_on_vector(uc%sym%op(abs(iop)), dr%iq(iq)%vel(:, b1))
+            end if
+            v2 = lo_outerproduct(v0, v1)
+            do a=1, 3
+            do b=1, 3
+            do c=1, 3
+            do d=1, 3
+                mu(a, b, c, d) = mu(a, b, c, d) + pref * kr(a) * v0(b) * kr(c) * v1(d) / qp%n_full_point
+!               mu(a, b, c, d) = mu(a, b, c, d) + pref * v2(a, b) * kr(c) * kr(d) / qp%n_full_point
+            end do
+            end do
+            end do
+            end do
+        end do
+    end do
+    mu = lo_chop(mu, sum(abs(mu))*1e-6_r8)
 end subroutine
 end module

--- a/src/thermal_conductivity/kappa.f90
+++ b/src/thermal_conductivity/kappa.f90
@@ -257,6 +257,7 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
                 if (dr%iq(iq)%omega(jmode) .lt. lo_freqtol) cycle
                 om1 = dr%iq(iq)%omega(jmode)
                 tau1 = dr%iq(iq)%linewidth(jmode)
+                ! Not needed almost always, but needed for some extremely rare pathological cases
                 if (tau1 .lt. lo_freqtol) cycle
                 do kmode = 1, dr%n_mode
                     if (jmode .eq. kmode) cycle  ! We only want the off diagonal contribution
@@ -265,6 +266,7 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
                     if (om2 .lt. lo_freqtol) cycle
 
                     tau2 = dr%iq(iq)%linewidth(kmode)
+                    ! Not needed almost always, but needed for some extremely rare pathological cases
                     if (tau2 .lt. lo_freqtol) cycle
 
                     ! This is consistent with the paper, but a bit different from QHGK
@@ -414,6 +416,7 @@ subroutine iterative_solution(sr, dr, qp, uc, temperature, niter, tol, classical
             do il = 1, sr%my_nqpoints
                 q1 = sr%my_qpoints(il)
                 b1 = sr%my_modes(il)
+                ! The check is needed for some extremely rare pathological cases
                 if (dr%iq(q1)%qs(b1) .lt. lo_freqtol) then
                     Fnb(:, b1, q1) = 0.0_r8
                 else

--- a/src/thermal_conductivity/scattering.f90
+++ b/src/thermal_conductivity/scattering.f90
@@ -1,7 +1,8 @@
 #include "precompilerdefinitions"
 module scattering
 use konstanter, only: r8, i8, lo_freqtol, lo_twopi, lo_exitcode_param, lo_hugeint, lo_pi, lo_tol, &
-                      lo_phonongroupveltol, lo_tol, lo_frequency_THz_to_Hartree, lo_kb_hartree, lo_huge
+                      lo_phonongroupveltol, lo_tol, lo_frequency_THz_to_Hartree, lo_kb_hartree, lo_huge, &
+                      lo_frequency_Hartree_to_meV
 use gottochblandat, only: walltime, lo_trueNtimes, lo_progressbar_init, lo_progressbar, lo_gauss, lo_planck, lo_return_unique
 use mpi_wrappers, only: lo_mpi_helper, lo_stop_gracefully
 use lo_memtracker, only: lo_mem_helper
@@ -83,8 +84,13 @@ subroutine generate(sr, qp, dr, uc, fct, fcf, opts, tmr, mw, mem)
         !> The q-point grid dimension
         integer, dimension(3) :: dims
         !> Some integers for the do loop/indices
-        integer :: q1, b1, il, j, my_nqpoints, ctr
-        !> The seed for the random number generator for the Monte-Carlo integration
+        integer :: q1, q2, b1, il, j, my_nqpoints, ctr
+
+        real(r8), dimension(:), allocatable :: sigavg, bla
+        real(r8), dimension(3, 3) :: reclat
+        real(r8), dimension(6) :: w
+        real(r8) :: sigma
+        integer, dimension(3) :: fq, fqp
 
         ! grid dimensions
         select type (qp)
@@ -116,8 +122,15 @@ subroutine generate(sr, qp, dr, uc, fct, fcf, opts, tmr, mw, mem)
         ! We can start some precomputation
         allocate (sr%be(qp%n_irr_point, dr%n_mode))
         allocate (sr%sigsq(qp%n_irr_point, dr%n_mode))
+        call mem%allocate(sigavg, dr%n_mode, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+        call mem%allocate(bla, dr%n_mode, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
         sr%be = 0.0_r8
         sr%sigsq = 0.0_r8
+        bla = 0.0_r8
+        sigavg = 0.0_r8
+        do j=1, 3
+            reclat(:, j) = uc%reciprocal_latticevectors(:, j) / dims(j)
+        end do
         do q1 = 1, qp%n_irr_point
             do b1 = 1, dr%n_mode
                 if (opts%classical) then
@@ -126,9 +139,57 @@ subroutine generate(sr, qp, dr, uc, fct, fcf, opts, tmr, mw, mem)
                     sr%be(q1, b1) = lo_planck(opts%temperature, dr%iq(q1)%omega(b1))
                 end if
 
-                sr%sigsq(q1, b1) = qp%smearingparameter(dr%iq(q1)%vel(:, b1), dr%default_smearing(b1), opts%sigma)**2
+                do j=1, 3
+                    w(j) = dot_product(dr%iq(q1)%vel(:, b1), reclat(:, j))**2
+                end do
+!               sigma = sum(w(1:3))
+                sigma = maxval(w(1:3))
+                sr%sigsq(q1, b1) = sigma
+                if (sigma .gt. 0) then
+                    sigavg(b1) = sigavg(b1) + sigma * qp%ip(q1)%integration_weight
+                    bla(b1) = bla(b1) + 1.0_r8
+                end if
+
+                fq = singlet_to_triplet(qp%ip(q1)%full_index, dims(2), dims(3))
+                do j=1, 3
+                    fqp = fq
+                    fqp(j) = mod(fqp(j) + 1, dims(j))
+                    if (fqp(j) .eq. 0) fqp(j) = dims(j)
+                    q2 = triplet_to_singlet(fqp, dims(2), dims(3))
+!                   w(j) = dot_product(dr%iq(q1)%vel(:, b1) - dr%aq(q2)%vel(:, b1), reclat(:, j))**2
+!                   w(j) = sum((dr%iq(q1)%vel(j, b1) * reclat(:, j))**2)
+                    w(j) = 0.5_r8 * (dr%iq(q1)%omega(b1) - dr%aq(q2)%omega(b1))
+
+                    fqp = fq
+                    fqp(j) = fqp(j) - 1
+                    if (fqp(j) .eq. 0) fqp(j) = dims(j)
+                    q2 = triplet_to_singlet(fqp, dims(2), dims(3))
+!                   w(j+3) = dot_product(dr%iq(q1)%vel(:, b1) - dr%aq(q2)%vel(:, b1), reclat(:, j))**2
+!                   w(j+3) = sum((dr%iq(q1)%vel(j, b1) * reclat(:, j))**2)
+                    w(j+3) = 0.5_r8 * (dr%iq(q1)%omega(b1) - dr%aq(q2)%omega(b1))
+
+                end do
+!               sigma = (sum(w * lo_twopi / sqrt(2.0_r8)) / 6.0_r8)**2
+                sigma = sum(w)**2 / 6.0_r8
+!               sigma = norm2(dr%iq(q1)%vel(:, b1)) * qp%ip(q1)%radius
+!               sigma = sigma**2
+!               sigma = maxval(w(1:3))
+                sigavg(b1) = sigavg(b1) + sigma * qp%ip(q1)%integration_weight
+                sr%sigsq(q1, b1) = sigma
+
+!               sr%sigsq(q1, b1) = qp%smearingparameter(dr%iq(q1)%vel(:, b1), minval(dr%default_smearing), opts%sigma)**2
+!               sr%sigsq(q1, b1) = qp%smearingparameter(dr%iq(q1)%vel(:, b1), dr%default_smearing(b1), opts%sigma)**2
             end do
         end do
+        sigavg = sigavg / bla
+        do q1=1, qp%n_irr_point
+            do b1=1, dr%n_mode
+                if (sqrt(sr%sigsq(q1, b1)) .lt. lo_freqtol) sr%sigsq(q1, b1) = sigavg(b1)
+            end do
+        end do
+        if (mw%talk) write(*, *) dr%default_smearing * lo_frequency_Hartree_to_meV
+        if (mw%talk) write(*, *) sqrt(sigavg) * lo_frequency_Hartree_to_meV
+        call mem%deallocate(sigavg, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
 
         if (mw%talk) write (*, *) '... distributing q-point/modes on MPI ranks'
         ctr = 0

--- a/src/thermal_conductivity/scattering.f90
+++ b/src/thermal_conductivity/scattering.f90
@@ -150,21 +150,20 @@ subroutine generate(sr, qp, dr, uc, fct, fcf, opts, tmr, mw, mem)
                 else
                     sr%be(q1, b1) = lo_planck(opts%temperature, dr%iq(q1)%omega(b1))
                 end if
-!               sr%sigsq(q1, b1) = qp%smearingparameter(dr%iq(q1)%vel(:, b1), dr%default_smearing(b1), 1.0_r8)**2
 
                 v0 = matmul(abs(dr%iq(q1)%vel(:, b1)), sr%reclat)**2
                 ! This allows to work around problems with 2D materials
                 sigma = maxval(v0*0.5_r8)
                 sr%sigsq(q1, b1) = sigma
 
-                ! Let's accumulate the average broadening factor for each mode, for a sanity check
+                ! Let's accumulate the average broadening factor for each mode
                 sigavg(b1) = sigavg(b1) + sigma * qp%ip(q1)%integration_weight
             end do
         end do
 
-        ! We add a little baseline as a sanity check, to avoid pathological case when group velocities are near zero
+        ! We add a little baseline, to avoid pathological case when group velocities are near zero
         sr%sigsq = sr%sigsq + maxval(sigavg) * 1e-4_r8
-        ! This is to have the sanity check in memory, for integrationtype 6
+        ! This is to have a sanity check in memory, for integrationtype 6
         sr%thresh_sigma = maxval(sigavg) * 1e-4_r8
         call mem%deallocate(sigavg, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
 

--- a/src/thermal_conductivity/scattering.f90
+++ b/src/thermal_conductivity/scattering.f90
@@ -152,7 +152,7 @@ subroutine generate(sr, qp, dr, uc, fct, fcf, opts, tmr, mw, mem)
 !               sr%sigsq(q1, b1) = qp%smearingparameter(dr%iq(q1)%vel(:, b1), dr%default_smearing(b1), 1.0_r8)**2
 
                 v0 = matmul(abs(dr%iq(q1)%vel(:, b1)), sr%reclat)**2
-                ! This allows to work around problem with 2D materials
+                ! This allows to work around problems with 2D materials
                 sigma = maxval(v0*0.5_r8)
                 sr%sigsq(q1, b1) = sigma
 

--- a/src/thermal_conductivity/scattering_fourphonon.f90
+++ b/src/thermal_conductivity/scattering_fourphonon.f90
@@ -341,7 +341,6 @@ subroutine get_dirac(sr, qp, dr, q1, q2, q3, q4, b1, b2, b3, b4, integrationtype
         d2 = 1.0_r8
         j = j + 1
     else
-
         if (abs(om1 - om2 - om3 - om4) .lt. 4.0_r8 * sigma) then
             d0 = d0 + lo_gauss(om1, om2 + om3 + om4, sigma)
             j = j + 1

--- a/src/thermal_conductivity/scattering_fourphonon.f90
+++ b/src/thermal_conductivity/scattering_fourphonon.f90
@@ -262,6 +262,7 @@ subroutine compute_fourphonon_scattering(il, sr, qp, dr, uc, fcf, mcg, rng, &
     call mem%deallocate(qgridfull1, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(qgridfull2, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(od_terms, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+    if (allocated(red_quartet)) deallocate(red_quartet)
 
     contains
 subroutine get_dirac(sr, qp, dr, q1, q2, q3, q4, b1, b2, b3, b4, integrationtype, d0, d1, d2, d3, isok)
@@ -456,6 +457,8 @@ subroutine quartet_is_irreducible(qp, uc, q1, q2, q3, q4, isred, red_quartet, mw
             newqp_sort(:, j) = qpp
             if (qpp(1) .gt. q2 .or. qpp(2) .gt. q3) isred = .true.
         end do
+
+        if (isred) return
 
         if (minval(newqp) .lt. 0) then
             do j = 1, size(newqp, 2)

--- a/src/thermal_conductivity/scattering_fourphonon.f90
+++ b/src/thermal_conductivity/scattering_fourphonon.f90
@@ -292,7 +292,7 @@ subroutine get_dirac(sr, qp, dr, q1, q2, q3, q4, b1, b2, b3, b4, integrationtype
     select case (integrationtype)
     ! Gaussian smearing with fixed width
     case (1)
-        sigma = smearing * lo_frequency_THz_to_Hartree
+        sigma = sr%sigma
     ! Adaptive Gaussian smearing with smeared frequency approach
     case (2)
         sigma = sqrt(sr%sigsq(q1, b1) + &
@@ -314,10 +314,8 @@ subroutine get_dirac(sr, qp, dr, q1, q2, q3, q4, b1, b2, b3, b4, integrationtype
         do i=1, 6
             sigma = sigma + sqrt(maxval(allsig(:, i)) * 0.5_r8) / 6.0_r8
         end do
+        sigma = sigma + sr%thresh_sigma
     end select
-    ! To catch edge cases, where the sum rule is actually working
-!   if (sigma .lt. lo_freqtol) sigma = 1.0_r8 / sqrt(lo_twopi)
-!   if (sigma .lt. lo_freqtol) sigma = minval(dr%default_smearing)
 
     d0 = 0.0_r8
     d1 = 0.0_r8
@@ -342,10 +340,6 @@ subroutine get_dirac(sr, qp, dr, q1, q2, q3, q4, b1, b2, b3, b4, integrationtype
         d2 = 1.0_r8
         j = j + 1
     else
-!       d0 = lo_gauss(om1, om2 + om3 + om4, sigma)  - lo_gauss(om1, -om2 - om3 - om4, sigma)
-!       d1 = lo_gauss(om1, -om2 + om3 + om4, sigma) - lo_gauss(om1, om2 - om3 - om4, sigma)
-!       d2 = lo_gauss(om1, -om3 + om2 + om4, sigma) - lo_gauss(om1, om3 - om2 - om4, sigma)
-!       d3 = lo_gauss(om1, -om4 + om3 + om2, sigma) - lo_gauss(om1, om4 - om3 - om2, sigma)
 
         if (abs(om1 - om2 - om3 - om4) .lt. 4.0_r8 * sigma) then
             d0 = d0 + lo_gauss(om1, om2 + om3 + om4, sigma)

--- a/src/thermal_conductivity/scattering_fourphonon.f90
+++ b/src/thermal_conductivity/scattering_fourphonon.f90
@@ -54,6 +54,8 @@ subroutine compute_fourphonon_scattering(il, sr, qp, dr, uc, fcf, mcg, rng, &
     real(r8) :: f0, f1, f2, f3, f4, f5, f6, f7, fall
     !> The reducible triplet corresponding to the currently computed quartet
     integer, dimension(:, :), allocatable :: red_quartet
+    !> The approximated dirac
+    real(r8) :: d0, d1, d2, d3, d4
 
     real(r8), dimension(:, :), allocatable :: od_terms
 
@@ -146,18 +148,20 @@ subroutine compute_fourphonon_scattering(il, sr, qp, dr, uc, fcf, mcg, rng, &
                     n4p = n4 + 1.0_r8
                     egv4 = dr%aq(q4)%egv(:, b4)/sqrt(om4)
 
-                    select case (integrationtype)
-                    case (1)
-                        sigma = smearing*lo_frequency_THz_to_Hartree
-                    case (2)
-                        sigma = sqrt(sr%sigsq(q1, b1) + &
-                                     sr%sigsq(qp%ap(q2)%irreducible_index, b2) + &
-                                     sr%sigsq(qp%ap(q3)%irreducible_index, b3) + &
-                                     sr%sigsq(qp%ap(q4)%irreducible_index, b4))
-                    case (6)
-                        sigma = qp%smearingparameter(dr%aq(q3)%vel(:, b3) - dr%aq(q4)%vel(:, b4), &
-                                                     dr%default_smearing(b3), smearing)
-                    end select
+!                   select case (integrationtype)
+!                   case (1)
+!                       sigma = smearing*lo_frequency_THz_to_Hartree
+!                   case (2)
+!                       sigma = sqrt(sr%sigsq(q1, b1) + &
+!                                    sr%sigsq(qp%ap(q2)%irreducible_index, b2) + &
+!                                    sr%sigsq(qp%ap(q3)%irreducible_index, b3) + &
+!                                    sr%sigsq(qp%ap(q4)%irreducible_index, b4))
+!                   case (6)
+!                       sigma = qp%smearingparameter(dr%aq(q3)%vel(:, b3) - dr%aq(q4)%vel(:, b4), &
+!                                                    dr%default_smearing(b3), smearing)
+!                   end select
+
+                    call get_dirac(sr, qp, dr, q1, q2, q3, q4, b1, b2, b3, b4, integrationtype, d0, d1, d2, d3)
 
                     evp3 = 0.0_r8
                     call zgeru(dr%n_mode, dr%n_mode**3, (1.0_r8, 0.0_r8), egv4, 1, evp2, 1, evp3, dr%n_mode)
@@ -172,10 +176,14 @@ subroutine compute_fourphonon_scattering(il, sr, qp, dr, uc, fcf, mcg, rng, &
                     plf3 = 3.0_r8*n4*n3p*n2p - n4p*n3*n2
 
                     ! Prefactors, including the matrix elements and dirac
-                    f0 = mult0*psisq*plf0*(lo_gauss(om1, om2 + om3 + om4, sigma) - lo_gauss(om1, -om2 - om3 - om4, sigma))
-                    f1 = mult1*psisq*plf1*(lo_gauss(om1, -om2 + om3 + om4, sigma) - lo_gauss(om1, om2 - om3 - om4, sigma))
-                    f2 = mult2*psisq*plf2*(lo_gauss(om1, -om3 + om2 + om4, sigma) - lo_gauss(om1, om3 - om2 - om4, sigma))
-                    f3 = mult3*psisq*plf3*(lo_gauss(om1, -om4 + om3 + om2, sigma) - lo_gauss(om1, om4 - om3 - om2, sigma))
+!                   f0 = mult0*psisq*plf0*(lo_gauss(om1, om2 + om3 + om4, sigma) - lo_gauss(om1, -om2 - om3 - om4, sigma))
+!                   f1 = mult1*psisq*plf1*(lo_gauss(om1, -om2 + om3 + om4, sigma) - lo_gauss(om1, om2 - om3 - om4, sigma))
+!                   f2 = mult2*psisq*plf2*(lo_gauss(om1, -om3 + om2 + om4, sigma) - lo_gauss(om1, om3 - om2 - om4, sigma))
+!                   f3 = mult3*psisq*plf3*(lo_gauss(om1, -om4 + om3 + om2, sigma) - lo_gauss(om1, om4 - om3 - om2, sigma))
+                    f0 = mult0*psisq*plf0*d0
+                    f1 = mult1*psisq*plf1*d1
+                    f2 = mult2*psisq*plf2*d2
+                    f3 = mult3*psisq*plf3*d3
 
                     fall = f0 + f1 + f2 + f3
 
@@ -268,6 +276,87 @@ subroutine compute_fourphonon_scattering(il, sr, qp, dr, uc, fcf, mcg, rng, &
     call mem%deallocate(qgridfull1, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(qgridfull2, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(od_terms, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
+
+    contains
+subroutine get_dirac(sr, qp, dr, q1, q2, q3, q4, b1, b2, b3, b4, integrationtype, d0, d1, d2, d3)
+    !> The scattering amplitudes
+    type(lo_scattering_rates), intent(in) :: sr
+    !> The qpoint mesh
+    class(lo_qpoint_mesh), intent(in) :: qp
+    !> Harmonic dispersions
+    type(lo_phonon_dispersions), intent(in) :: dr
+    !> The qpoints
+    integer, intent(in) :: q1, q2, q3, q4
+    !> The modes
+    integer, intent(in) :: b1, b2, b3, b4
+    !> THe integration type
+    integer, intent(in) :: integrationtype
+    !> The approximated dirac
+    real(r8), intent(out) :: d0, d1, d2, d3
+
+    !> The frequencies
+    real(r8) :: om1, om2, om3, om4
+    ! Buffer to contains all the sigmas
+    real(r8), dimension(3, 6) :: allsig
+    !> An integer for the do loop
+    integer :: i
+
+    select case (integrationtype)
+    ! Gaussian smearing with fixed width
+    case (1)
+        sigma = smearing * lo_frequency_THz_to_Hartree
+    ! Adaptive Gaussian smearing with smeared frequency approach
+    case (2)
+        sigma = sqrt(sr%sigsq(q1, b1) + &
+                     sr%sigsq(qp%ap(q2)%irreducible_index, b2) + &
+                     sr%sigsq(qp%ap(q3)%irreducible_index, b3) + &
+                     sr%sigsq(qp%ap(q4)%irreducible_index, b4))
+    ! Adaptive Gaussian smearing with velocity difference approach
+    case (6)
+        ! We take an average to respect the symmetry of the scattering matrix
+        allsig = 0.0_r8
+
+        allsig(:, 1) = matmul(dr%iq(q1)%vel(:, b1) - dr%aq(q2)%vel(:, b2), sr%reclat)**2
+        allsig(:, 2) = matmul(dr%iq(q1)%vel(:, b1) - dr%aq(q3)%vel(:, b3), sr%reclat)**2
+        allsig(:, 3) = matmul(dr%iq(q1)%vel(:, b1) - dr%aq(q4)%vel(:, b4), sr%reclat)**2
+        allsig(:, 4) = matmul(dr%aq(q2)%vel(:, b2) - dr%aq(q3)%vel(:, b3), sr%reclat)**2
+        allsig(:, 5) = matmul(dr%aq(q2)%vel(:, b2) - dr%aq(q4)%vel(:, b4), sr%reclat)**2
+        allsig(:, 6) = matmul(dr%aq(q3)%vel(:, b3) - dr%aq(q4)%vel(:, b4), sr%reclat)**2
+        sigma = 0.0_r8
+        do i=1, 6
+            sigma = sigma + sqrt(maxval(allsig(:, i)) * 0.5_r8) / 6.0_r8
+        end do
+    end select
+    ! To catch edge cases, where the sum rule is actually working
+!   if (sigma .lt. lo_freqtol) sigma = 1.0_r8 / sqrt(lo_twopi)
+!   if (sigma .lt. lo_freqtol) sigma = minval(dr%default_smearing)
+
+    d0 = 0.0_r8
+    d1 = 0.0_r8
+    d2 = 0.0_r8
+    d3 = 0.0_r8
+
+    om1 = dr%iq(q1)%omega(b1)
+    om2 = dr%aq(q2)%omega(b2)
+    om3 = dr%aq(q3)%omega(b3)
+    om4 = dr%aq(q4)%omega(b4)
+    ! We can have some cases actually respecting strictly the sum rules
+    if (abs(om1 - om2) .lt. lo_freqtol .and. abs(om3 - om4) .lt. lo_freqtol) then
+        d2 = 1.0_r8
+        d3 = 1.0_r8
+    elseif (abs(om1 - om3) .lt. lo_freqtol .and. abs(om2 - om4) .lt. lo_freqtol) then
+        d1 = 1.0_r8
+        d3 = 1.0_r8
+    elseif (abs(om1 - om4) .lt. lo_freqtol .and. abs(om2 - om3) .lt. lo_freqtol) then
+        d1 = 1.0_r8
+        d2 = 1.0_r8
+    else
+        d0 = lo_gauss(om1, om2 + om3 + om4, sigma)  - lo_gauss(om1, -om2 - om3 - om4, sigma)
+        d1 = lo_gauss(om1, -om2 + om3 + om4, sigma) - lo_gauss(om1, om2 - om3 - om4, sigma)
+        d2 = lo_gauss(om1, -om3 + om2 + om4, sigma) - lo_gauss(om1, om3 - om2 - om4, sigma)
+        d3 = lo_gauss(om1, -om4 + om3 + om2, sigma) - lo_gauss(om1, om4 - om3 - om2, sigma)
+    end if
+end subroutine
 end subroutine
 
 subroutine quartet_is_irreducible(qp, uc, q1, q2, q3, q4, isred, red_quartet, mw, mem)

--- a/src/thermal_conductivity/scattering_isotope.f90
+++ b/src/thermal_conductivity/scattering_isotope.f90
@@ -53,9 +53,7 @@ subroutine compute_isotope_scattering(il, sr, qp, dr, uc, temperature, &
             case (6)
                 allsig = matmul(dr%aq(q2)%vel(:, b2), sr%reclat)**2
                 sigma = sqrt(maxval(allsig) * 0.5_r8)
-                sigma = max(sigma, dr%default_smearing(b2) * 0.25_r8)
-!               sigma = qp%smearingparameter(dr%aq(q2)%vel(:, b2), &
-!                                            dr%default_smearing(b2), smearing)
+                sigma = sigma + sr%thresh_sigma
             end select
 
             i = (q2 - 1)*dr%n_mode + b2

--- a/src/thermal_conductivity/scattering_isotope.f90
+++ b/src/thermal_conductivity/scattering_isotope.f90
@@ -31,7 +31,7 @@ subroutine compute_isotope_scattering(il, sr, qp, dr, uc, temperature, &
     ! prefactor and phonon buffers
     real(r8) :: om1, om2, sigma, psisq, prefactor, f0
     ! Integers for do loops
-    integer :: q1, b1, q2, b2, i, niso
+    integer :: q1, b1, q2, b2, i2, niso
 
     q1 = sr%my_qpoints(il)
     b1 = sr%my_modes(il)
@@ -56,7 +56,7 @@ subroutine compute_isotope_scattering(il, sr, qp, dr, uc, temperature, &
                 sigma = sigma + sr%thresh_sigma
             end select
 
-            i = (q2 - 1)*dr%n_mode + b2
+            i2 = (q2 - 1)*dr%n_mode + b2
 
             egviso(:, 2) = dr%aq(q2)%egv(:, b2)
 
@@ -64,7 +64,7 @@ subroutine compute_isotope_scattering(il, sr, qp, dr, uc, temperature, &
 
             f0 = psisq*om1*om2*lo_gauss(om1, om2, sigma)
             g0 = g0 + f0
-            sr%Xi(il, i) = sr%Xi(il, i) + f0*om2/om1
+            sr%Xi(il, i2) = sr%Xi(il, i2) + f0*om2/om1
         end do
     end do
 end subroutine

--- a/src/thermal_conductivity/scattering_isotope.f90
+++ b/src/thermal_conductivity/scattering_isotope.f90
@@ -56,10 +56,10 @@ subroutine compute_isotope_scattering(il, sr, qp, dr, uc, temperature, &
                 sigma = sigma + sr%thresh_sigma
             end select
 
+            ! The off-diagonal index in the scattering matrix
             i2 = (q2 - 1)*dr%n_mode + b2
 
             egviso(:, 2) = dr%aq(q2)%egv(:, b2)
-
             psisq = isotope_scattering_strength(uc, egviso)*prefactor
 
             f0 = psisq*om1*om2*lo_gauss(om1, om2, sigma)

--- a/src/thermal_conductivity/scattering_isotope.f90
+++ b/src/thermal_conductivity/scattering_isotope.f90
@@ -26,6 +26,8 @@ subroutine compute_isotope_scattering(il, sr, qp, dr, uc, temperature, &
 
     ! Eigenvectors
     complex(r8), dimension(uc%na*3, 2) :: egviso
+    !> For the broadening calculation
+    real(r8), dimension(3) :: allsig
     ! prefactor and phonon buffers
     real(r8) :: om1, om2, sigma, psisq, prefactor, f0
     ! Integers for do loops
@@ -49,8 +51,11 @@ subroutine compute_isotope_scattering(il, sr, qp, dr, uc, temperature, &
                 sigma = sqrt(sr%sigsq(q1, b1) + &
                              sr%sigsq(qp%ap(q2)%irreducible_index, b2))
             case (6)
-                sigma = qp%smearingparameter(dr%aq(q2)%vel(:, b2), &
-                                             dr%default_smearing(b2), smearing)
+                allsig = matmul(dr%aq(q2)%vel(:, b2), sr%reclat)**2
+                sigma = sqrt(maxval(allsig) * 0.5_r8)
+                sigma = max(sigma, dr%default_smearing(b2) * 0.25_r8)
+!               sigma = qp%smearingparameter(dr%aq(q2)%vel(:, b2), &
+!                                            dr%default_smearing(b2), smearing)
             end select
 
             i = (q2 - 1)*dr%n_mode + b2

--- a/src/thermal_conductivity/scattering_threephonon.f90
+++ b/src/thermal_conductivity/scattering_threephonon.f90
@@ -200,7 +200,6 @@ subroutine compute_threephonon_scattering(il, sr, qp, dr, uc, fct, mcg, rng, &
         end do allq2
 
         ! And now we add things, with the normalization
-        od_terms = od_terms
         do q2 = 1, qp%n_full_point
             do b2 = 1, dr%n_mode
                 i2 = (q2 - 1)*dr%n_mode + b2

--- a/src/thermal_conductivity/scattering_threephonon.f90
+++ b/src/thermal_conductivity/scattering_threephonon.f90
@@ -123,8 +123,6 @@ subroutine compute_threephonon_scattering(il, sr, qp, dr, uc, fct, mcg, rng, &
                 ! The prefactor for the scattering
                 plf0 = n2 - n3
                 plf1 = n2 + n3 + 1.0_r8
-!               f0 = perm*psisq*plf0*(lo_gauss(om1, -om2 + om3, sigma) - lo_gauss(om1, om2 - om3, sigma))
-!               f1 = perm*psisq*plf1*(lo_gauss(om1, om2 + om3, sigma) - lo_gauss(om1, -om2 - om3, sigma))
                 f0 = perm*psisq*plf0*d0
                 f1 = perm*psisq*plf1*d1
 
@@ -220,7 +218,7 @@ subroutine compute_threephonon_scattering(il, sr, qp, dr, uc, fct, mcg, rng, &
     call mem%deallocate(egv3, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(qgridfull, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%deallocate(od_terms, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
-    deallocate (red_triplet)
+    if (allocated(red_triplet)) deallocate (red_triplet)
 
     contains
 subroutine get_dirac(sr, qp, dr, q1, q2, q3, b1, b2, b3, integrationtype, d0, d1, isok)

--- a/src/thermal_conductivity/scattering_threephonon.f90
+++ b/src/thermal_conductivity/scattering_threephonon.f90
@@ -49,6 +49,13 @@ subroutine compute_threephonon_scattering(il, sr, qp, dr, uc, fct, mcg, rng, &
     !> buff to keep the off diagonal scattering matrix elements
     real(r8), dimension(:, :), allocatable :: od_terms
 
+    real(r8), dimension(3, 3) :: reclat
+    real(r8), dimension(3) :: w
+
+    do i=1, 3
+        reclat(:, i) = uc%reciprocal_latticevectors(:, i) / mcg%full_dims(i)
+    end do
+
     ! We start by allocating everything
     call mem%allocate(ptf, dr%n_mode**3, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
     call mem%allocate(evp1, dr%n_mode**2, persistent=.false., scalable=.false., file=__FILE__, line=__LINE__)
@@ -107,8 +114,13 @@ subroutine compute_threephonon_scattering(il, sr, qp, dr, uc, fct, mcg, rng, &
                                  sr%sigsq(qp%ap(q2)%irreducible_index, b2) + &
                                  sr%sigsq(qp%ap(q3)%irreducible_index, b3))
                 case (6)
-                    sigma = qp%smearingparameter(dr%aq(q2)%vel(:, b2) - dr%aq(q3)%vel(:, b3), &
-                                                 dr%default_smearing(b3), smearing)
+!                   sigma = qp%smearingparameter(dr%aq(q2)%vel(:, b2) - dr%aq(q3)%vel(:, b3), &
+!                                                dr%default_smearing(b3), smearing)
+
+                    do i=1, 3
+                        w(i) = dot_product(dr%aq(q2)%vel(:, b2) - dr%aq(q3)%vel(:, b3), reclat(:, i))**2
+                    end do
+                    sigma = sqrt(maxval(w) * 0.5_r8)
                 end select
 
                 ! This is the multiplication of eigv of phonons 1 and 2 and now 3


### PR DESCRIPTION
The default smearing for adaptive gaussian integration can be too large in some cases (steep acoustic phonons for example, like in Si or BAs).
This PR fix this problem in the thermal_conductivity binary