### PR TITLE
Fix aliasing violation and out-of-bounds write in lo_permutations

### DIFF
--- a/src/libolle/gottochblandat_sorting.f90
+++ b/src/libolle/gottochblandat_sorting.f90
@@ -787,7 +787,7 @@ module subroutine lo_permutations(p,n)
         if (pos > pos_max) then
             ! store this one
             k=k+1
-            pm(:,i)=permutation
+            pm(:,k)=permutation
         else
             do val = val_min,val_max
                 if (.not. any (permutation(:pos-1) == val)) then


### PR DESCRIPTION
### Description
This PR fixes a critical Fortran standard violation (aliasing) in `gottochblandat_sorting.f90` that causes silent heap corruption and subsequent `Segmentation fault` (SIGSEGV) when compiling with modern compilers (like `gfortran 9.3+`) under `-O2` or `-O3` optimization.

### The Bug
In the `lo_permutations` subroutine, the recursive `generate` function takes the loop counter as a dummy argument `k`. However, internally it was writing to the array using the outer variable `i`:
`pm(:,i) = permutation`

Under `-O2` optimization, register caching causes this to repeatedly write to `pm(:,0)` (an out-of-bounds write), which silently overwrites the heap descriptors and crashes the program later during deallocation.

### The Fix
Changed the array index to use the correct local dummy argument:
`pm(:,k) = permutation`

This ensures strict compliance with the Fortran standard and completely resolves the memory corruption issue on optimized builds.