### PR TITLE
Keep the full complex generalized group velocity in kappa_offdiag

### DIFF
--- a/src/thermal_conductivity/kappa.f90
+++ b/src/thermal_conductivity/kappa.f90
@@ -95,7 +95,7 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
     real(r8), dimension(3, 3), intent(out) :: kappa_offdiag
 
     !> The off diagonal group velocity
-    real(r8), dimension(:, :, :), allocatable :: buf_vel
+    complex(r8), dimension(:, :, :), allocatable :: buf_vel
     !> The off diagonal group velocity, squared
     real(r8), dimension(:, :, :, :), allocatable :: buf_velsq
     !> The qpoint
@@ -116,7 +116,7 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
             complex(r8), dimension(:, :, :), allocatable :: buf_grad_dynmat
             complex(r8), dimension(:, :), allocatable :: kronegv, buf_egv, buf_egw, buf_cm0, buf_cm1, buf_cm2
             complex(r8), dimension(3) :: cv0
-            real(r8), dimension(3) :: v0, v1
+            complex(r8), dimension(3) :: v0, v1
             integer :: a1, a2, ia, ib, ic, ix, iy, iz, k, iop, i, ii, j, jj
 
             ! Some buffers
@@ -207,9 +207,12 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
                 cv0 = buf_cm2(ii, :)
                 ! remove tiny numbers.
                 cv0 = lo_chop(cv0, 1E-10/(lo_groupvel_Hartreebohr_to_ms/1000))
-                ! I can take the real part since at the end we sum over
-                ! both modes and the imaginary components disappear.
-                buf_vel(:, i, j) = real(cv0, r8)
+                ! Keep the full complex velocity. The imaginary parts do cancel
+                ! in sum_ij v_ij, but the quantity accumulated below is quadratic
+                ! and sum_ij Im v^a Im v^b does not vanish. Discarding it makes
+                ! kappa_offdiag depend on the arbitrary phases of the eigenvectors
+                ! returned by zheev.
+                buf_vel(:, i, j) = cv0
             end do
             end do
 
@@ -226,7 +229,10 @@ subroutine get_kappa_offdiag(dr, qp, uc, fc, temperature, classical, mem, mw, ka
                 do k = 1, qp%ip(iq)%n_full_point
                     iop = qp%ip(iq)%operation_full_point(k)
                     v1 = matmul(uc%sym%op(abs(iop))%m, v0)
-                    buf_velsq(:, :, i, j) = buf_velsq(:, :, i, j) + lo_outerproduct(v1, v1)
+                    ! lo_outerproduct conjugates its first argument, so the real part
+                    ! here is Re v^a Re v^b + Im v^a Im v^b, the gauge invariant form.
+                    buf_velsq(:, :, i, j) = buf_velsq(:, :, i, j) + &
+                                            real(lo_outerproduct(v1, v1), r8)
                 end do
             end do
             end do


### PR DESCRIPTION
# Keep the full complex generalized group velocity in `kappa_offdiag`

## The bug

`get_kappa_offdiag` drops the imaginary part of the off-diagonal group velocity:

```fortran
! I can take the real part since at the end we sum over
! both modes and the imaginary components disappear.
buf_vel(:, i, j) = real(cv0, r8)
```

The premise is true — `v_ij = conj(v_ji)`, so `sum_ij Im v_ij = 0` — but `buf_vel` is not summed linearly. It is accumulated quadratically,

```fortran
buf_velsq(:, :, i, j) = buf_velsq(:, :, i, j) + lo_outerproduct(v1, v1)
```

and `sum_ij Im v^a Im v^b` does not vanish. What is left, `Re v^a Re v^b`, is not invariant under `v_ss' -> exp(i(th_s' - th_s)) v_ss'`, so `kappa_offdiag` depends on the arbitrary phases that `zheev` returns for the eigenvectors.

## The fix

Keep `cv0` complex and take the real part of the outer product instead:

```fortran
buf_vel(:, i, j) = cv0
...
buf_velsq(:, :, i, j) = buf_velsq(:, :, i, j) + &
                        real(lo_outerproduct(v1, v1), r8)
```

`lo_complex_outerproduct(a, b)` is `m(i,j) = conj(a(j)) * b(i)`, so this gives `Re v^a Re v^b + Im v^a Im v^b`, the gauge-invariant combination. `buf_vel` and the local `v0`, `v1` in `get_kappa_offdiag` become complex; the variables of the same name in `get_kappa` are untouched.

The fix in this branch [`fix/coherence-gauge-invariance`](https://github.com/Surefire618/tdep/tree/fix/coherence-gauge-invariance) is prepared for a merge.

## Evidence

MgO from `tdep-tutorials/04_thermal_conductivity/Examples/MgO`, 300 K, third order, isotope scattering on, adaptive Gaussian integration, one MPI rank.

### Gauge-invariance test (test only branch, do no merge)

To test gauge invariance I  prepared a random-phase-injection patch, available as the branch [`Surefire618:random_phase_injection`](https://github.com/Surefire618/tdep/tree/random_phase_injection). It multiplies every eigenvector by a random phase, `e_s -> exp(i th_s) e_s`, before the off-diagonal velocity is built.

The patch is enabled by setting the environment variable `TDEP_GAUGE_SEED`:

```bash
export TDEP_GAUGE_SEED=1
thermal_conductivity -qg 8 8 8 --temperature 300
```

The original behaviour is recovered by taking the real part of the velocities:

```fortran
! buf_vel(:, i, j) = cv0
buf_vel(:, i, j) = real(cv0, r8)
```

A sanity check confirms that the phased vectors are still orthonormal and are still eigenvectors with the same eigenvalues. The patch also writes `v_ss'` to `outfile.velocity_offdiagonal`. This test branch [`Surefire618:random_phase_injection`](https://github.com/Surefire618/tdep/tree/random_phase_injection) is for diagnostics only and is not proposed for merging.

The coherence channel at 8³ reads:

| gauge | original (W/mK) | fixed (W/mK) |
|---|---|---|
| none | 0.088432413 | 0.099657622 |
| `TDEP_GAUGE_SEED=1` | 0.041501821 | 0.099657622 |
| `TDEP_GAUGE_SEED=2` | 0.038095586 | 0.099657622 |
| `TDEP_GAUGE_SEED=3` | 0.075441779 | 0.099657622 |

The input files and the `thermal_conductivity` log files are attached for reference:
[mgo_gauge.tar.gz](https://github.com/user-attachments/files/31062128/mgo_gauge.tar.gz)